### PR TITLE
Add `bigcode-evaluation-harness` support

### DIFF
--- a/GenAIEval/evaluation/bigcode_evaluation_harness/__init__.py
+++ b/GenAIEval/evaluation/bigcode_evaluation_harness/__init__.py
@@ -1,0 +1,2 @@
+from .accuracy import evaluate
+from .arguments import BigcodeEvalParser, setup_parser

--- a/GenAIEval/evaluation/bigcode_evaluation_harness/accuracy.py
+++ b/GenAIEval/evaluation/bigcode_evaluation_harness/accuracy.py
@@ -1,0 +1,229 @@
+import fnmatch
+import json
+import os
+import warnings
+
+import datasets
+import torch
+import transformers
+from accelerate import Accelerator
+# from bigcode_eval.arguments import EvalArguments
+from bigcode_eval.evaluator import Evaluator
+from bigcode_eval.tasks import ALL_TASKS
+from transformers import (AutoModelForCausalLM, AutoModelForSeq2SeqLM,
+                          AutoTokenizer, HfArgumentParser)
+
+
+def pattern_match(patterns, source_list):
+    """Returns a list containing all values of the source_list that
+    match at least one of the patterns"""
+    task_names = set()
+    for pattern in patterns:
+        for matching in fnmatch.filter(source_list, pattern):
+            task_names.add(matching)
+    return list(task_names)
+
+
+def get_gpus_max_memory(max_memory, num_gpus):
+    max_memory = {i: max_memory for i in range(num_gpus)}
+    print("Loading model via these GPUs & max memories: ", max_memory)
+    return max_memory
+
+
+def clean_args(args):
+    remove_parameters = ["tokenizer", "user_model"]
+    for parameter in remove_parameters:
+        if hasattr(args, parameter):
+            delattr(args, parameter)
+
+
+def evaluate(args):
+    transformers.logging.set_verbosity_error()
+    datasets.logging.set_verbosity_error()
+
+    if args.tasks is None:
+        task_names = ALL_TASKS
+    else:
+        task_names = pattern_match(args.tasks.split(","), ALL_TASKS)
+
+    accelerator = Accelerator()
+    if accelerator.is_main_process:
+        print(f"Selected Tasks: {task_names}")
+
+    results = {}
+
+    if args.load_generations_path:
+        # here we don't generate code but only evaluate previously computed generations
+        if accelerator.is_main_process:
+            print("evaluation only mode")
+        evaluator = Evaluator(accelerator, None, None, args)
+        for task in task_names:
+            results[task] = evaluator.evaluate(task)
+    else:
+        # here we generate code and save it (evaluation is optional but True by default)
+        dict_precisions = {
+            "fp32": torch.float32,
+            "fp16": torch.float16,
+            "bf16": torch.bfloat16,
+        }
+        if args.precision not in dict_precisions:
+            raise ValueError(
+                f"Non valid precision {args.precision}, choose from: fp16, fp32, bf16"
+            )
+
+        model_kwargs = {
+            "revision": args.revision,
+            "trust_remote_code": args.trust_remote_code,
+            "use_auth_token": args.use_auth_token,
+        }
+
+        if not hasattr(args, "user_model") or args.user_model[0] is None:
+            if args.load_in_8bit:
+                print("Loading model in 8bit")
+                model_kwargs["load_in_8bit"] = args.load_in_8bit
+                model_kwargs["device_map"] = {"": accelerator.process_index}
+            elif args.load_in_4bit:
+                print("Loading model in 4bit")
+                model_kwargs["load_in_4bit"] = args.load_in_4bit
+                model_kwargs["device_map"] = {"": accelerator.process_index}
+            else:
+                print(f"Loading model in {args.precision}")
+                model_kwargs["torch_dtype"] = dict_precisions[args.precision]
+
+                if args.max_memory_per_gpu:
+                    if args.max_memory_per_gpu != "auto":
+                        model_kwargs["max_memory"] = get_gpus_max_memory(
+                            args.max_memory_per_gpu, accelerator.num_processes
+                        )
+                        model_kwargs["offload_folder"] = "offload"
+                    else:
+                        model_kwargs["device_map"] = "auto"
+                        print("Loading model in auto mode")
+
+            if args.modeltype == "causal":
+                model = AutoModelForCausalLM.from_pretrained(
+                    args.model,
+                    **model_kwargs,
+                )
+            elif args.modeltype == "seq2seq":
+                warnings.warn(
+                    "Seq2Seq models have only been tested for HumanEvalPack & CodeT5+ models."
+                )
+                model = AutoModelForSeq2SeqLM.from_pretrained(
+                    args.model,
+                    **model_kwargs,
+                )
+            else:
+                raise ValueError(
+                    f"Non valid modeltype {args.modeltype}, choose from: causal, seq2seq"
+                )
+
+            if args.peft_model:
+                from peft import \
+                    PeftModel  # dynamic import to avoid dependency on peft
+
+                model = PeftModel.from_pretrained(model, args.peft_model)
+                print("Loaded PEFT model. Merging...")
+                model.merge_and_unload()
+                print("Merge complete.")
+        else:
+            model = args.user_model[0]
+
+        if not hasattr(args, "tokenizer") or args.tokenizer[0] is None:
+            if args.left_padding:
+                # left padding is required for some models like chatglm3-6b
+                tokenizer = AutoTokenizer.from_pretrained(
+                    args.model,
+                    revision=args.revision,
+                    trust_remote_code=args.trust_remote_code,
+                    use_auth_token=args.use_auth_token,
+                    padding_side="left",
+                )
+            else:
+                # used by default for most models
+                tokenizer = AutoTokenizer.from_pretrained(
+                    args.model,
+                    revision=args.revision,
+                    trust_remote_code=args.trust_remote_code,
+                    use_auth_token=args.use_auth_token,
+                    truncation_side="left",
+                    padding_side="right",
+                )
+        else:
+            tokenizer = args.tokenizer[0]
+        if not tokenizer.eos_token:
+            if tokenizer.bos_token:
+                tokenizer.eos_token = tokenizer.bos_token
+                print("bos_token used as eos_token")
+            else:
+                raise ValueError("No eos_token or bos_token found")
+        try:
+            tokenizer.pad_token = tokenizer.eos_token
+
+        # Some models like CodeGeeX2 have pad_token as a read-only property
+        except AttributeError:
+            print("Not setting pad_token to eos_token")
+            pass
+        WIZARD_LLAMA_MODELS = [
+            "WizardLM/WizardCoder-Python-34B-V1.0",
+            "WizardLM/WizardCoder-34B-V1.0",
+            "WizardLM/WizardCoder-Python-13B-V1.0",
+        ]
+        if args.model in WIZARD_LLAMA_MODELS:
+            tokenizer.bos_token = "<s>"
+            tokenizer.bos_token_id = 1
+            print("Changing bos_token to <s>")
+
+        evaluator = Evaluator(accelerator, model, tokenizer, args)
+
+        if args.load_generations_intermediate_paths and len(
+            args.load_generations_intermediate_paths
+        ) != len(task_names):
+            raise ValueError(
+                "If passing --load_generations_intermediate_paths, \
+                must pass equal number of files as number of tasks"
+            )
+
+        for idx, task in enumerate(task_names):
+            intermediate_generations = None
+            if args.load_generations_intermediate_paths:
+                with open(args.load_generations_intermediate_paths[idx], "r") as f_in:
+                    # intermediate_generations: list[list[str | None]] of len n_tasks
+                    # where list[i] = generated codes or empty
+                    intermediate_generations = json.load(f_in)
+
+            if args.generation_only:
+                if accelerator.is_main_process:
+                    print("generation mode only")
+                generations, references = evaluator.generate_text(
+                    task, intermediate_generations=intermediate_generations
+                )
+                if accelerator.is_main_process:
+                    save_generations_path = (
+                        f"{os.path.splitext(args.save_generations_path)[0]}_{task}.json"
+                    )
+                    save_references_path = f"references_{task}.json"
+                    evaluator.save_json_files(
+                        generations,
+                        references,
+                        save_generations_path,
+                        save_references_path,
+                    )
+            else:
+                results[task] = evaluator.evaluate(
+                    task, intermediate_generations=intermediate_generations
+                )
+
+    # Save all args to config
+    clean_args(args)
+    results["config"] = vars(args)
+
+    if not args.generation_only:
+        dumped = json.dumps(results, indent=2)
+        if accelerator.is_main_process:
+            print(dumped)
+
+        with open(args.metric_output_path, "w") as f:
+            f.write(dumped)
+
+    return results

--- a/GenAIEval/evaluation/bigcode_evaluation_harness/arguments.py
+++ b/GenAIEval/evaluation/bigcode_evaluation_harness/arguments.py
@@ -1,0 +1,291 @@
+import fnmatch
+
+from bigcode_eval.arguments import EvalArguments
+from bigcode_eval.tasks import ALL_TASKS
+from transformers import HfArgumentParser
+
+
+class MultiChoice:
+    def __init__(self, choices):
+        self.choices = choices
+
+    # Simple wildcard support (linux filename patterns)
+    def __contains__(self, values):
+        for value in values.split(","):
+            if len(fnmatch.filter(self.choices, value)) == 0:
+                return False
+
+        return True
+
+    def __iter__(self):
+        for choice in self.choices:
+            yield choice
+
+
+def setup_parser():
+    parser = HfArgumentParser(EvalArguments)
+
+    parser.add_argument(
+        "--model",
+        default="codeparrot/codeparrot-small",
+        help="Model to evaluate, provide a repo name in Hugging Face hub or a local path",
+    )
+    parser.add_argument(
+        "--modeltype",
+        default="causal",
+        help="AutoModel to use, it can be causal or seq2seq",
+    )
+    parser.add_argument(
+        "--peft_model",
+        type=str,
+        default=None,
+        help="Adapter to the PEFT base model. Can be utilized for loading PEFT adapters such as a LoRA trained model. The --model parameter needs to be the base model.",
+    )
+    parser.add_argument(
+        "--revision",
+        default=None,
+        help="Model revision to use",
+    )
+    parser.add_argument(
+        "--use_auth_token",
+        action="store_true",
+        help="Use the token generated when running `huggingface-cli login` (necessary for private model).",
+    )
+    parser.add_argument(
+        "--trust_remote_code",
+        action="store_true",
+        help="Use a model with custom code, this requires executing code by the author of the model.",
+    )
+    parser.add_argument(
+        "--tasks",
+        default=None,
+        choices=MultiChoice(ALL_TASKS),
+        help=f"Evaluation tasks from {ALL_TASKS}",
+    )
+    parser.add_argument(
+        "--instruction_tokens",
+        default=None,
+        help="A series of instruction tokens used for instruction-tuning benchamrks separated by comma e.g. <user_message>,<end_user_message>,<assistant_message>",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=1,
+        help="Batch size for evaluation on each worker, can be larger for HumanEval",
+    )
+    parser.add_argument(
+        "--max_length_generation",
+        type=int,
+        default=512,
+        help="Maximum length of generated sequence (prompt+generation)",
+    )
+    parser.add_argument(
+        "--precision",
+        type=str,
+        default="fp32",
+        help="Model precision, from: fp32, fp16 or bf16",
+    )
+    parser.add_argument(
+        "--load_in_8bit",
+        action="store_true",
+        help="Load model in 8bit",
+    )
+    parser.add_argument(
+        "--load_in_4bit",
+        action="store_true",
+        help="Load model in 4bit",
+    )
+    parser.add_argument(
+        "--left_padding",
+        action="store_true",
+        help="Force left padding, needed for models like chatglm3-6b",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Number of samples to solve and evaluate from the benchmark",
+    )
+    parser.add_argument(
+        "--limit_start",
+        type=int,
+        default=0,
+        help="Optional offset to start from when limiting the number of samples",
+    )
+    parser.add_argument(
+        "--save_every_k_tasks",
+        type=int,
+        default=-1,
+        help="Optional saving after every k tasks",
+    )
+    parser.add_argument(
+        "--postprocess",
+        action="store_false",
+        help="Postprocess model outputs before execution, always on except during generation tests",
+    )
+    parser.add_argument(
+        "--allow_code_execution",
+        action="store_true",
+        help="Allow code evaluation to execute external/untrusted Python code on your machine",
+    )
+    parser.add_argument(
+        "--generation_only",
+        action="store_true",
+        help="Do code generation but no evaluation",
+    )
+    parser.add_argument(
+        "--load_generations_path",
+        type=str,
+        default=None,
+        help="Path of file with previously generated solutions, if provided generation is skipped and only evaluation is done",
+    )
+    parser.add_argument(
+        "--load_data_path",
+        type=str,
+        default=None,
+        help="Path of additional data to load for the tasks",
+    )
+    parser.add_argument(
+        "--metric_output_path",
+        type=str,
+        default="evaluation_results.json",
+        help="Path to save the results",
+    )
+    parser.add_argument(
+        "--save_generations",
+        action="store_true",
+        help="Whether to save code generations",
+    )
+    parser.add_argument(
+        "--load_generations_intermediate_paths",
+        type=str,
+        nargs="*",
+        help="List of paths for saving the intermediate code generations",
+    )
+    parser.add_argument(
+        "--save_generations_path",
+        type=str,
+        default="generations.json",
+        help="Path for saving the code generations",
+    )
+    parser.add_argument(
+        "--save_references",
+        action="store_true",
+        help="Whether to save reference solutions/tests",
+    )
+    parser.add_argument(
+        "--save_references_path",
+        type=str,
+        default="references.json",
+        help="Path for saving the references solutions/tests",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default="prompt",
+        help="Prompt type to use for generation in HumanEvalPack tasks",
+    )
+    parser.add_argument(
+        "--max_memory_per_gpu",
+        type=str,
+        default=None,
+        help="Max memroy to allocate per gpu, you can also use 'auto'",
+    )
+    parser.add_argument(
+        "--check_references",
+        action="store_true",
+        help="Don't run generation but benchmark groundtruth (useful for debugging)",
+    )
+    return parser.parse_args()
+
+
+class BigcodeEvalParser:
+    """
+    the class is the another form of `setup_parser` function and used for function call pass parameters.
+    """
+
+    def __init__(
+        self,
+        prefix="",  # EvalArguments
+        do_sample=True,
+        temperature=0.2,
+        top_k=0,
+        top_p=0.95,
+        n_samples=1,
+        eos="<|endoftext|>",
+        seed=0,
+        model="codeparrot/codeparrot-small",  # BigcodeEvalArguments
+        modeltype="causal",
+        peft_model=None,
+        revision=None,
+        use_auth_token=False,
+        trust_remote_code=False,
+        tasks=None,
+        instruction_tokens=None,
+        batch_size=1,
+        max_length_generation=512,
+        precision="fp32",
+        load_in_8bit=False,
+        load_in_4bit=False,
+        left_padding=False,
+        limit=None,
+        limit_start=0,
+        save_every_k_tasks=-1,
+        postprocess=True,
+        allow_code_execution=False,
+        generation_only=False,
+        load_generations_path=None,
+        load_data_path=None,
+        metric_output_path="evaluation_results.json",
+        save_generations=False,
+        load_generations_intermediate_paths="",
+        save_generations_path="generations.json",
+        save_references=False,
+        save_references_path="references.json",
+        prompt="prompt",
+        max_memory_per_gpu=None,
+        check_references=False,
+        user_model=None,  # used for pass model object
+        tokenizer=None,  # used for pass tokenizer object
+    ):
+        self.prefix = prefix
+        self.do_sample = do_sample
+        self.temperature = temperature
+        self.top_k = top_k
+        self.top_p = top_p
+        self.n_samples = n_samples
+        self.eos = eos
+        self.seed = seed
+        self.model = model
+        self.modeltype = modeltype
+        self.peft_model = peft_model
+        self.revision = revision
+        self.use_auth_token = use_auth_token
+        self.trust_remote_code = trust_remote_code
+        self.tasks = tasks
+        self.instruction_tokens = instruction_tokens
+        self.batch_size = batch_size
+        self.max_length_generation = max_length_generation
+        self.precision = precision
+        self.load_int_8bit = load_in_8bit
+        self.load_in_4bit = load_in_4bit
+        self.left_padding = left_padding
+        self.limit = limit
+        self.limit_start = limit_start
+        self.save_every_k_tasks = save_every_k_tasks
+        self.postprocess = postprocess
+        self.allow_code_execution = allow_code_execution
+        self.generation_only = generation_only
+        self.load_generations_path = load_generations_path
+        self.load_data_path = load_data_path
+        self.metric_output_path = metric_output_path
+        self.save_generations = save_generations
+        self.load_generations_intermediate_paths = load_generations_intermediate_paths
+        self.save_generations_path = save_generations_path
+        self.save_references = save_references
+        self.save_references_path = save_references_path
+        self.prompt = prompt
+        self.max_memory_per_gpu = max_memory_per_gpu
+        self.check_references = check_references
+        self.user_model = user_model
+        self.tokenizer = tokenizer

--- a/GenAIEval/evaluation/lm_evaluation_harness/__init__.py
+++ b/GenAIEval/evaluation/lm_evaluation_harness/__init__.py
@@ -1,2 +1,2 @@
 from .accuracy import cli_evaluate as evaluate
-from .arguments import LMEvalParser, setup_parser, parse_eval_args
+from .arguments import LMEvalParser, setup_parser

--- a/GenAIEval/evaluation/lm_evaluation_harness/accuracy.py
+++ b/GenAIEval/evaluation/lm_evaluation_harness/accuracy.py
@@ -9,14 +9,13 @@ from pathlib import Path
 from typing import Union
 
 import numpy as np
-
 from lm_eval import utils
-from .lm_eval import evaluator
-from .lm_eval.evaluator import request_caching_arg_to_dict
 from lm_eval.logging_utils import WandbLogger
 from lm_eval.tasks import TaskManager
 from lm_eval.utils import make_table, simple_parse_args_string
 
+from .lm_eval import evaluator
+from .lm_eval.evaluator import request_caching_arg_to_dict
 
 DEFAULT_RESULTS_FILE = "results.json"
 
@@ -91,8 +90,8 @@ def cli_evaluate(args) -> None:
                     f"{utils.SPACING}Try `lm-eval --tasks list` for list of available tasks",
                 )
                 raise ValueError(
-                    f"Tasks not found: {missing}. Try `lm-eval --tasks list` for list of available tasks," + \
-                    " or '--verbosity DEBUG' to troubleshoot task registration issues."
+                    f"Tasks not found: {missing}. Try `lm-eval --tasks list` for list of available tasks,"
+                    + " or '--verbosity DEBUG' to troubleshoot task registration issues."
                 )
 
     if args.output_path:
@@ -148,8 +147,12 @@ def cli_evaluate(args) -> None:
         random_seed=args.seed[0],
         numpy_random_seed=args.seed[1],
         torch_random_seed=args.seed[2],
-        user_model=args.user_model if hasattr(args, "user_model") else None, # to validate the model in memory,
-        tokenizer=args.tokenizer if hasattr(args, "tokenizer") else None, # to use tokenizer in mem,
+        user_model=(
+            args.user_model if hasattr(args, "user_model") else None
+        ),  # to validate the model in memory,
+        tokenizer=(
+            args.tokenizer if hasattr(args, "tokenizer") else None
+        ),  # to use tokenizer in mem,
         **request_caching_args,
     )
 
@@ -205,4 +208,3 @@ def cli_evaluate(args) -> None:
             wandb_logger.run.finish()
 
     return results
-

--- a/GenAIEval/evaluation/lm_evaluation_harness/arguments.py
+++ b/GenAIEval/evaluation/lm_evaluation_harness/arguments.py
@@ -1,6 +1,7 @@
 import argparse
 from functools import partial
 
+
 def _int_or_none_list_arg_type(max_len: int, value: str, split_char: str = ","):
     def parse_value(item):
         item = item.strip().lower()
@@ -24,6 +25,7 @@ def _int_or_none_list_arg_type(max_len: int, value: str, split_char: str = ","):
 
     return items
 
+
 def check_argument_types(parser: argparse.ArgumentParser):
     """
     Check to make sure all CLI args are typed, raises error if not
@@ -36,6 +38,7 @@ def check_argument_types(parser: argparse.ArgumentParser):
                 )
             else:
                 continue
+
 
 def setup_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
@@ -198,45 +201,47 @@ def setup_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Sets trust_remote_code to True to execute code to create HF Datasets from the Hub",
     )
-
-    return parser
-
-def parse_eval_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
     check_argument_types(parser)
     return parser.parse_args()
 
+
 class LMEvalParser:
-    def __init__(self,
-                 model="hf",
-                 tasks="lambada_openai",
-                 model_args="",
-                 user_model=None,
-                 tokenizer=None,
-                 num_fewshot=None,
-                 batch_size=1,
-                 max_batch_size=None,
-                 device=None,
-                 output_path=None,
-                 limit=None,
-                 use_cache=None,
-                 cache_requests=None,
-                 check_integrity=False,
-                 write_out=False,
-                 log_samples=False,
-                 show_config=False,
-                 include_path=None,
-                 gen_kwargs=None,
-                 verbosity="INFO",
-                 wandb_args="",
-                 predict_only=False,
-                 seed=[0, 1234, 1234],
-                 trust_remote_code=False
-                 ):
+    """
+    The class is the another form of `setup_parser` function and used for function call pass parameters.
+    """
+
+    def __init__(
+        self,
+        model="hf",
+        tasks="lambada_openai",
+        model_args="",
+        user_model=None,
+        tokenizer=None,
+        num_fewshot=None,
+        batch_size=1,
+        max_batch_size=None,
+        device=None,
+        output_path=None,
+        limit=None,
+        use_cache=None,
+        cache_requests=None,
+        check_integrity=False,
+        write_out=False,
+        log_samples=False,
+        show_config=False,
+        include_path=None,
+        gen_kwargs=None,
+        verbosity="INFO",
+        wandb_args="",
+        predict_only=False,
+        seed=[0, 1234, 1234],
+        trust_remote_code=False,
+    ):
         self.model = model
         self.tasks = tasks
         self.model_args = model_args
-        self.user_model=user_model
-        self.tokenizer=tokenizer
+        self.user_model = user_model
+        self.tokenizer = tokenizer
         self.num_fewshot = num_fewshot
         self.batch_size = batch_size
         self.max_batch_size = max_batch_size

--- a/GenAIEval/evaluation/lm_evaluation_harness/lm_eval/evaluator.py
+++ b/GenAIEval/evaluation/lm_evaluation_harness/lm_eval/evaluator.py
@@ -1,31 +1,25 @@
 import itertools
 import logging
+import os
 import random
 import time
-import os
 from collections import defaultdict
 from typing import TYPE_CHECKING, List, Optional, Union
-
-import numpy as np
-import torch
 
 import lm_eval.api.metrics
 import lm_eval.api.registry
 import lm_eval.models
+import numpy as np
+import torch
+from lm_eval import utils
 from lm_eval.caching.cache import delete_cache
-from lm_eval.evaluator_utils import (
-    consolidate_results,
-    get_sample_size,
-    get_task_list,
-    prepare_print_tasks,
-    print_writeout,
-    run_task_tests,
-)
+from lm_eval.evaluator_utils import (consolidate_results, get_sample_size,
+                                     get_task_list, prepare_print_tasks,
+                                     print_writeout, run_task_tests)
 from lm_eval.logging_utils import add_env_info, get_git_commit_hash
 from lm_eval.tasks import TaskManager, get_task_dict
-from lm_eval.utils import eval_logger, positional_deprecated, simple_parse_args_string
-from lm_eval import utils
-
+from lm_eval.utils import (eval_logger, positional_deprecated,
+                           simple_parse_args_string)
 
 if TYPE_CHECKING:
     from lm_eval.api.model import LM
@@ -35,7 +29,7 @@ if TYPE_CHECKING:
 @positional_deprecated
 def simple_evaluate(
     model,
-    model_args: Optional[Union[str, dict,object]] = None,
+    model_args: Optional[Union[str, dict, object]] = None,
     tasks: Optional[List[Union[str, dict, object]]] = None,
     num_fewshot: Optional[int] = None,
     batch_size: Optional[int] = None,
@@ -158,14 +152,17 @@ def simple_evaluate(
             model_args = ""
         # replace HFLM.
         from .models.huggingface import HFLM
+
         lm_eval.api.registry.MODEL_REGISTRY["hf-auto"] = HFLM
         lm_eval.api.registry.MODEL_REGISTRY["hf"] = HFLM
         lm_eval.api.registry.MODEL_REGISTRY["huggingface"] = HFLM
 
         if user_model is not None:
             # use tiny model to built lm.
-            print("We use 'pretrained=Muennighoff/tiny-random-bert'" +
-                  "to build `LM` instance, the actually run model is user_model you passed.")
+            print(
+                "We use 'pretrained=Muennighoff/tiny-random-bert'"
+                + "to build `LM` instance, the actually run model is user_model you passed."
+            )
             lm = lm_eval.api.registry.get_model(model).create_from_arg_string(
                 "pretrained=Muennighoff/tiny-random-bert",
                 {
@@ -242,8 +239,8 @@ def simple_evaluate(
         if num_fewshot is not None:
             if (default_num_fewshot := task_obj.get_config("num_fewshot")) == 0:
                 eval_logger.info(
-                    f"num_fewshot has been set to 0 for {task_name} in its config." + \
-                    "Manual configuration will be ignored."
+                    f"num_fewshot has been set to 0 for {task_name} in its config."
+                    + "Manual configuration will be ignored."
                 )
             else:
                 eval_logger.warning(
@@ -297,9 +294,7 @@ def simple_evaluate(
         try:
             add_env_info(results)  # additional environment info to results
         except:
-            eval_logger.info(
-                    f"get env info failed."
-                )
+            eval_logger.info(f"get env info failed.")
         return results
     else:
         return None

--- a/GenAIEval/evaluation/lm_evaluation_harness/lm_eval/models/__init__.py
+++ b/GenAIEval/evaluation/lm_evaluation_harness/lm_eval/models/__init__.py
@@ -1,7 +1,4 @@
-from . import (
-    huggingface,
-)
-
+from . import huggingface
 
 # TODO: implement __all__
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Evaluation, benchmark, and scorecard, targeting for performance on throughput an
 
 ## Evaluation
 ### lm-evaluation-harness
-We follow the [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness/tree/main) and provide the command line usage and function call usage.
+For evaluating the models on text-generation tasks, we follow the [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness/) and provide the command line usage and function call usage. Over 60 standard academic benchmarks for LLMs, with hundreds of [subtasks and variants](https://github.com/EleutherAI/lm-evaluation-harness/tree/v0.4.2/lm_eval/tasks) implemented, such as `ARC`, `HellaSwag`, `MMLU`, `TruthfulQA`, `Winogrande`, `GSM8K` and so on.
 #### command line usage
 ```shell
 python main.py --model hf \
@@ -14,13 +14,43 @@ python main.py --model hf \
 ```
 #### function call usage
 ```python
-from GenAIEval.evaluation.lm_evaluate import evaluate, LMEvalParser
+from GenAIEval.evaluation.lm_evaluate_harness import evaluate, LMEvalParser
 args = LMevalParser(model = "hf", 
                     user_model = user_model,
                     tokenizer = tokenizer,
                     tasks = "hellaswag",
                     device = "cpu",
                     batch_size = 8,
+                    )
+results = evaluate(args)
+```
+
+### bigcode-evaluation-harness
+For evaluating the models on coding tasks or specifically coding LLMs, we follow the [bigcode-evaluation-harness](https://github.com/bigcode-project/bigcode-evaluation-harness) and provide the command line usage and function call usage. [HumanEval](https://huggingface.co/datasets/openai_humaneval), [HumanEval+](https://huggingface.co/datasets/evalplus/humanevalplus), [InstructHumanEval](https://huggingface.co/datasets/codeparrot/instructhumaneval), [APPS](https://huggingface.co/datasets/codeparrot/apps), [MBPP](https://huggingface.co/datasets/mbpp), [MBPP+](https://huggingface.co/datasets/evalplus/mbppplus), and [DS-1000](https://github.com/HKUNLP/DS-1000/) for both completion (left-to-right) and insertion (FIM) mode are available.
+#### command line usage
+There is a small code change in `main.py` regarding the import path.
+```diff
+- from GenAIEval.evaluation.lm_evaluation_harness import evaluate, setup_parser
++ from GenAIEval.evaluation.bigcode_evaluation_harness import evaluate, setup_parser
+```
+```shell
+python main.py \
+    --model "codeparrot/codeparrot-small" \
+    --tasks "humaneval" \
+    --n_samples 100 \
+    --batch_size 10 \
+    --allow_code_execution \
+```
+#### function call usage
+```python
+from GenAIEval.evaluation.bigcode_evaluation_harness import evaluate, BigcodeEvalParser
+args = BigcodeEvalParser(
+                    user_model = user_model,
+                    tokenizer = tokenizer,
+                    tasks = "humaneval",
+                    n_samples = 100,
+                    batch_size = 10,
+                    allow_code_execution=True,
                     )
 results = evaluate(args)
 ```

--- a/main.py
+++ b/main.py
@@ -1,17 +1,12 @@
-from transformers import AutoModelForCausalLM, AutoTokenizer
-model_name_or_path = "facebook/opt-125m"
-user_model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
-tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+from GenAIEval.evaluation.lm_evaluation_harness import evaluate, setup_parser
 
-from GenAIEval.evaluation.lm_evaluation_harness import evaluate, setup_parser, parse_eval_args
-def parse_args():
-    parser = setup_parser()
-    args = parse_eval_args(parser)
-    return args
+# from GenAIEval.evaluation.bigcode_evaluation_harness import evaluate, setup_parser
+
 
 def main():
-    args = parse_args()
-    results = evaluate(args)
+    eval_args = setup_parser()
+    results = evaluate(eval_args)
+
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lm-eval==0.4.2
+git+https://github.com/bigcode-project/bigcode-evaluation-harness.git@a1b4a7949a24c8e3ef0d05a01097b2d14ffba56e
 

--- a/tests/test_bigcode_eval.py
+++ b/tests/test_bigcode_eval.py
@@ -1,0 +1,30 @@
+import unittest
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from GenAIEval.evaluation.bigcode_evaluation_harness import (BigcodeEvalParser,
+                                                             evaluate)
+
+
+class TestLMEval(unittest.TestCase):
+    def test_lm_eval(self):
+        model_name_or_path = "codeparrot/codeparrot-small"
+        user_model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_name_or_path, truncation_side="left", padding_side="right"
+        )
+        args = BigcodeEvalParser(
+            user_model=user_model,
+            tokenizer=tokenizer,
+            tasks="humaneval",
+            n_samples=20,
+            batch_size=10,
+            allow_code_execution=True,
+            limit=20,
+        )
+        results = evaluate(args)
+        self.assertEqual(results["humaneval"]["pass@1"], 0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lm_eval.py
+++ b/tests/test_lm_eval.py
@@ -1,20 +1,27 @@
 import unittest
+
 from transformers import AutoModelForCausalLM, AutoTokenizer
-from GenAIEval.evaluation.lm_evaluation_harness import evaluate, LMEvalParser
+
+from GenAIEval.evaluation.lm_evaluation_harness import LMEvalParser, evaluate
+
+
 class TestLMEval(unittest.TestCase):
     def test_lm_eval(self):
         model_name_or_path = "facebook/opt-125m"
         user_model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
         tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
-        args = LMEvalParser(model = "hf", 
-                            user_model = user_model,
-                            tokenizer = tokenizer,
-                            tasks = "piqa",
-                            device = "cpu",
-                            batch_size = 1,
-                            limit = 5)
+        args = LMEvalParser(
+            model="hf",
+            user_model=user_model,
+            tokenizer=tokenizer,
+            tasks="piqa",
+            device="cpu",
+            batch_size=1,
+            limit=5,
+        )
         results = evaluate(args)
         self.assertEqual(results["results"]["piqa"]["acc,none"], 0.6)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### command line usage
There is a small code change in `main.py` regarding the import path.
```diff
- from GenAIEval.evaluation.lm_evaluation_harness import evaluate, setup_parser
+ from GenAIEval.evaluation.bigcode_evaluation_harness import evaluate, setup_parser
```
```shell
python main.py \
    --model "codeparrot/codeparrot-small" \
    --tasks "humaneval" \
    --n_samples 100 \
    --batch_size 10 \
    --allow_code_execution \
```
#### function call usage
```python
from GenAIEval.evaluation.bigcode_evaluation_harness import evaluate, BigcodeEvalParser
args = BigcodeEvalParser(
                    user_model = user_model,
                    tokenizer = tokenizer,
                    tasks = "humaneval",
                    n_samples = 100,
                    batch_size = 10,
                    allow_code_execution=True,
                    )
results = evaluate(args)
```