### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ python main.py \
     --tasks "humaneval" \
     --n_samples 100 \
     --batch_size 10 \
-    --allow_code_execution \
+    --allow_code_execution
 ```
 #### function call usage
 ```python


### PR DESCRIPTION
## Type of Change

This is a minor documentation fix

## Description

The extra `\` and the end of command here needs to be removed: https://github.com/opea-project/GenAIEval?tab=readme-ov-file#command-line-usage-1

## How has this PR been tested?

Yes

## Dependency Change?

No
