### PR TITLE
improve ragas metrics random issue

### DIFF
--- a/evals/metrics/ragas/__init__.py
+++ b/evals/metrics/ragas/__init__.py
@@ -6,10 +6,5 @@
 #
 
 from .ragas import (
-    RAGASContextualPrecisionMetric,
-    RAGASContextualRelevancyMetric,
-    RAGASAnswerRelevancyMetric,
-    RAGASFaithfulnessMetric,
-    RAGASContextualRecallMetric,
     RagasMetric,
 )

--- a/evals/metrics/ragas/ragas.py
+++ b/evals/metrics/ragas/ragas.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #
-
+import os
 from typing import Dict, Optional, Union
 
 from langchain_community.llms import HuggingFaceEndpoint
@@ -22,7 +22,7 @@ class RagasMetric:
     def __init__(
         self,
         threshold: float = 0.3,
-        model: Optional[Union[str, BaseLanguageModel]] = "gpt-3.5-turbo",
+        model: Optional[Union[str, BaseLanguageModel]] = None,
         embeddings: Optional[Embeddings] = None,
         metrics: Optional[list[str]] = None,
     ):
@@ -56,6 +56,10 @@ class RagasMetric:
         }
 
         # Set LLM model
+        openai_key = os.getenv("OPENAI_API_KEY", None)
+        if openai_key is not None:
+            print("OPENAI_API_KEY is provided, ragas initializes the model by OpenAI .")
+            self.model = None
         if isinstance(self.model, str):
             chat_model = HuggingFaceEndpoint(
                 endpoint_url=self.model,

--- a/evals/metrics/ragas/ragas.py
+++ b/evals/metrics/ragas/ragas.py
@@ -58,7 +58,7 @@ class RagasMetric:
         # Set LLM model
         openai_key = os.getenv("OPENAI_API_KEY", None)
         if openai_key is not None:
-            print("OPENAI_API_KEY is provided, ragas initializes the model by OpenAI .")
+            print("OPENAI_API_KEY is provided, ragas initializes the model by OpenAI.")
             self.model = None
         if isinstance(self.model, str):
             chat_model = HuggingFaceEndpoint(
@@ -74,7 +74,14 @@ class RagasMetric:
             # check supported list
             for metric in self.metrics:
                 if metric not in self.validated_list:
-                    raise ValueError("metric should be in supported list {}.".format(self.validated_metrics))
+                    raise ValueError(
+                        "metric should be in supported list {}. ".format(self.validated_list)
+                        + "ClientResponseError raised with LangchainLLM "
+                        + "when context_precision, context_recall ran. "
+                        + "Here are the related issues described in ragas "
+                        "https://github.com/explodinggradients/ragas/issues/934, "
+                        + "https://github.com/explodinggradients/ragas/issues/664."
+                    )
                 else:
                     if metric == "answer_relevancy" and self.embeddings is None:
                         raise ValueError("answer_relevancy metric need provide embeddings model.")

--- a/evals/metrics/ragas/ragas.py
+++ b/evals/metrics/ragas/ragas.py
@@ -7,328 +7,13 @@
 
 from typing import Dict, Optional, Union
 
+from langchain_community.llms import HuggingFaceEndpoint
 from langchain_core.embeddings import Embeddings
 from langchain_core.language_models import BaseLanguageModel
-from langchain_huggingface import HuggingFaceEndpoint
 
 
 def format_ragas_metric_name(name: str):
     return f"{name} (ragas)"
-
-
-class RAGASContextualPrecisionMetric:
-    """This metric checks the contextual precision using Ragas."""
-
-    def __init__(
-        self,
-        threshold: float = 0.3,
-        model: Optional[Union[str, BaseLanguageModel]] = "gpt-3.5-turbo",
-    ):
-        self.threshold = threshold
-        self.model = model
-
-    def measure(self, test_case: Dict):
-        try:
-            from ragas import evaluate
-            from ragas.llms import LangchainLLMWrapper
-            from ragas.metrics import context_precision
-
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Please install ragas to use this metric. `pip install ragas`.")
-
-        try:
-            from datasets import Dataset
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Please install dataset")
-
-        # Set LLM model
-        if isinstance(self.model, str):
-            chat_model = HuggingFaceEndpoint(
-                endpoint_url=self.model,
-                timeout=600,
-            )
-        else:
-            chat_model = self.model
-        chat_model = LangchainLLMWrapper(chat_model)
-        # Create a dataset from the test case
-        data = {
-            "contexts": [test_case["retrieval_context"]],
-            "question": [test_case["input"]],
-            "ground_truth": [test_case["expected_output"]],
-        }
-        dataset = Dataset.from_dict(data)
-
-        # Evaluate the dataset using Ragas
-        scores = evaluate(dataset, metrics=[context_precision], llm=chat_model)
-        # Ragas only does dataset-level comparisons
-        context_precision_score = scores["context_precision"]
-        self.success = context_precision_score >= self.threshold
-        self.score = context_precision_score
-        return self.score
-
-    async def a_measure(self, test_case: Dict):
-        return self.measure(test_case)
-
-    def is_successful(self):
-        return self.success
-
-    @property
-    def __name__(self):
-        return format_ragas_metric_name("Contextual Precision")
-
-
-class RAGASContextualRelevancyMetric:
-    """This metric checks the contextual relevancy using Ragas."""
-
-    def __init__(
-        self,
-        threshold: float = 0.3,
-        model: Optional[Union[str, BaseLanguageModel]] = "gpt-3.5-turbo",
-    ):
-        self.threshold = threshold
-        self.model = model
-
-    async def a_measure(self, test_case: Dict):
-        return self.measure(test_case)
-
-    def measure(self, test_case: Dict):
-        # sends to server
-        try:
-            from ragas import evaluate
-            from ragas.llms import LangchainLLMWrapper
-            from ragas.metrics import context_relevancy
-
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Please install ragas to use this metric. `pip install ragas`.")
-
-        try:
-            from datasets import Dataset
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Please install dataset")
-
-        # Set LLM model
-        if isinstance(self.model, str):
-            chat_model = HuggingFaceEndpoint(
-                endpoint_url=self.model,
-                timeout=600,
-            )
-        else:
-            chat_model = self.model
-        chat_model = LangchainLLMWrapper(chat_model)
-        # Create a dataset from the test case
-        data = {
-            "contexts": [test_case["retrieval_context"]],
-            "question": [test_case["input"]],
-        }
-        dataset = Dataset.from_dict(data)
-
-        # Evaluate the dataset using Ragas
-        scores = evaluate(dataset, metrics=[context_relevancy], llm=chat_model)
-
-        # Ragas only does dataset-level comparisons
-        context_relevancy_score = scores["context_relevancy"]
-        self.success = context_relevancy_score >= self.threshold
-        self.score = context_relevancy_score
-        return self.score
-
-    def is_successful(self):
-        return self.success
-
-    @property
-    def __name__(self):
-        return format_ragas_metric_name("Contextual Relevancy")
-
-
-class RAGASAnswerRelevancyMetric:
-    """This metric checks the answer relevancy using Ragas."""
-
-    def __init__(
-        self,
-        threshold: float = 0.3,
-        model: Optional[Union[str, BaseLanguageModel]] = "gpt-3.5-turbo",
-        embeddings: Optional[Embeddings] = None,
-    ):
-
-        self.threshold = threshold
-        self.model = model
-        self.embeddings = embeddings
-
-    async def a_measure(self, test_case: Dict):
-        return self.measure(test_case)
-
-    def measure(self, test_case: Dict):
-        # sends to server
-        try:
-            from ragas import evaluate
-            from ragas.llms import LangchainLLMWrapper
-            from ragas.metrics import answer_relevancy
-
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Please install ragas to use this metric. `pip install ragas`.")
-
-        try:
-            from datasets import Dataset
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Please install dataset")
-
-        # Set LLM model
-        if isinstance(self.model, str):
-            chat_model = HuggingFaceEndpoint(
-                endpoint_url=self.model,
-                timeout=600,
-            )
-        else:
-            chat_model = self.model
-        chat_model = LangchainLLMWrapper(chat_model)
-        data = {
-            "question": [test_case["input"]],
-            "answer": [test_case["actual_output"]],
-            "contexts": [test_case["retrieval_context"]],
-        }
-        dataset = Dataset.from_dict(data)
-
-        scores = evaluate(
-            dataset,
-            metrics=[answer_relevancy],
-            llm=chat_model,
-            embeddings=self.embeddings,
-        )
-        answer_relevancy_score = scores["answer_relevancy"]
-        self.success = answer_relevancy_score >= self.threshold
-        self.score = answer_relevancy_score
-        return self.score
-
-    def is_successful(self):
-        return self.success
-
-    @property
-    def __name__(self):
-        return format_ragas_metric_name("Answer Relevancy")
-
-
-class RAGASFaithfulnessMetric:
-    def __init__(
-        self,
-        threshold: float = 0.3,
-        model: Optional[Union[str, BaseLanguageModel]] = "gpt-3.5-turbo",
-    ):
-
-        self.threshold = threshold
-        self.model = model
-
-    async def a_measure(self, test_case: Dict):
-        return self.measure(test_case)
-
-    def measure(self, test_case: Dict):
-        # sends to server
-        try:
-            from ragas import evaluate
-            from ragas.llms import LangchainLLMWrapper
-            from ragas.metrics import faithfulness
-
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Please install ragas to use this metric. `pip install ragas`.")
-
-        try:
-            from datasets import Dataset
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Please install dataset")
-
-        # Set LLM model
-        if isinstance(self.model, str):
-            chat_model = HuggingFaceEndpoint(
-                endpoint_url=self.model,
-                timeout=600,
-            )
-        else:
-            chat_model = self.model
-        chat_model = LangchainLLMWrapper(chat_model)
-        data = {
-            "contexts": [test_case["retrieval_context"]],
-            "question": [test_case["input"]],
-            "answer": [test_case["actual_output"]],
-        }
-        dataset = Dataset.from_dict(data)
-
-        scores = evaluate(
-            dataset,
-            metrics=[faithfulness],
-            llm=chat_model,
-        )
-        faithfulness_score = scores["faithfulness"]
-        self.success = faithfulness_score >= self.threshold
-        self.score = faithfulness_score
-        return self.score
-
-    def is_successful(self):
-        return self.success
-
-    @property
-    def __name__(self):
-        return format_ragas_metric_name("Faithfulness")
-
-
-class RAGASContextualRecallMetric:
-    """This metric checks the context recall using Ragas."""
-
-    def __init__(
-        self,
-        threshold: float = 0.3,
-        model: Optional[Union[str, BaseLanguageModel]] = "gpt-3.5-turbo",
-    ):
-        self.threshold = threshold
-        self.model = model
-
-    async def a_measure(self, test_case: Dict):
-        return self.measure(test_case)
-
-    def measure(self, test_case: Dict):
-        # sends to server
-        try:
-            from ragas import evaluate
-            from ragas.llms import LangchainLLMWrapper
-            from ragas.metrics import context_recall
-
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Please install ragas to use this metric. `pip install ragas`.")
-
-        try:
-            from datasets import Dataset
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Please install dataset")
-
-        # Set LLM model
-        if isinstance(self.model, str):
-            chat_model = HuggingFaceEndpoint(
-                endpoint_url=self.model,
-                timeout=600,
-            )
-        else:
-            chat_model = self.model
-        chat_model = LangchainLLMWrapper(chat_model)
-        data = {
-            "question": [test_case["input"]],
-            "ground_truth": [test_case["expected_output"]],
-            "contexts": [test_case["retrieval_context"]],
-        }
-        dataset = Dataset.from_dict(data)
-
-        scores = evaluate(
-            dataset,
-            [context_recall],
-            llm=chat_model,
-        )
-        context_recall_score = scores["context_recall"]
-        self.success = context_recall_score >= self.threshold
-        self.score = context_recall_score
-        return self.score
-
-    def is_successful(self):
-        return self.success
-
-    @property
-    def __name__(self):
-        return format_ragas_metric_name("Contextual Recall")
 
 
 class RagasMetric:
@@ -339,47 +24,79 @@ class RagasMetric:
         threshold: float = 0.3,
         model: Optional[Union[str, BaseLanguageModel]] = "gpt-3.5-turbo",
         embeddings: Optional[Embeddings] = None,
+        metrics: Optional[list[str]] = None,
     ):
 
         self.threshold = threshold
         self.model = model
         self.embeddings = embeddings
+        self.metrics = metrics
+        self.validated_list = ["answer_relevancy", "faithfulness"]
 
     async def a_measure(self, test_case: Dict):
         return self.measure(test_case)
 
     def measure(self, test_case: Dict):
+
         # sends to server
         try:
             from ragas import evaluate
+            from ragas.metrics import answer_relevancy, faithfulness
+
         except ModuleNotFoundError:
             raise ModuleNotFoundError("Please install ragas to use this metric. `pip install ragas`.")
 
         try:
-            # How do i make sure this isn't just huggingface dataset
             from datasets import Dataset
         except ModuleNotFoundError:
             raise ModuleNotFoundError("Please install dataset")
+        self.metrics_instance = {
+            "answer_relevancy": answer_relevancy,
+            "faithfulness": faithfulness,
+        }
 
+        # Set LLM model
+        if isinstance(self.model, str):
+            chat_model = HuggingFaceEndpoint(
+                endpoint_url=self.model,
+                timeout=600,
+            )
+        else:
+            chat_model = self.model
         # Create a dataset from the test case
         # Convert the Dict to a format compatible with Dataset
-        score_breakdown = {}
-        metrics = [
-            RAGASContextualPrecisionMetric(model=self.model),
-            RAGASContextualRecallMetric(model=self.model),
-            RAGASFaithfulnessMetric(model=self.model),
-            RAGASAnswerRelevancyMetric(model=self.model, embeddings=self.embeddings),
-        ]
+        if self.metrics is not None:
+            tmp_metrics = []
+            # check supported list
+            for metric in self.metrics:
+                if metric not in self.validated_list:
+                    raise ValueError("metric should be in supported list {}.".format(self.validated_metrics))
+                else:
+                    if metric == "answer_relevancy" and self.embeddings is None:
+                        raise ValueError("answer_relevancy metric need provide embeddings model.")
+                    tmp_metrics.append(metric)
+            self.metrics = tmp_metrics
+        else:
+            self.metrics = [
+                answer_relevancy,
+                faithfulness,
+            ]
 
-        for metric in metrics:
-            score = metric.measure(test_case)
-            score_breakdown[metric.__name__] = score
+        data = {
+            "question": [test_case["input"]],
+            "contexts": [test_case["retrieval_context"]],
+            "answer": [test_case["actual_output"]],
+            "ground_truth": [test_case["expected_output"]],
+        }
+        dataset = Dataset.from_dict(data)
 
-        ragas_score = sum(score_breakdown.values()) / len(score_breakdown)
-
-        self.success = ragas_score >= self.threshold
-        self.score = ragas_score
-        self.score_breakdown = score_breakdown
+        self.score = evaluate(
+            dataset,
+            metrics=self.metrics,
+            llm=chat_model,
+            embeddings=self.embeddings,
+        )
+        print(self.score)
         return self.score
 
     def is_successful(self):

--- a/tests/test_ragas.py
+++ b/tests/test_ragas.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-#
+
 import unittest
 
 from evals.metrics.ragas import RagasMetric
@@ -11,7 +11,7 @@ from evals.metrics.ragas import RagasMetric
 
 class TestRagasMetric(unittest.TestCase):
 
-    @unittest.skip("need assign localhost id")
+    @unittest.skip("need pass localhost id")
     def test_ragas(self):
         # Replace this with the actual output from your LLM application
         actual_output = "We offer a 30-day full refund at no extra cost."


### PR DESCRIPTION
## Description

discussed with @XuhuiRen  @lkk12014402, metrics context_recall, context_precision have random issue, the issue also be raised in ragas, so remove these first.
https://github.com/explodinggradients/ragas/issues/664
https://github.com/explodinggradients/ragas/issues/934
usage:
```
metric = RagasMetric(threshold=0.5, model="http://10.45.76.150:8008", embeddings=embeddings, metics=["answer_relevancy", "faithfulness" ])
# only model is necessary, others parameters have default values.
```
test_ragas.py local test results
```
(test) [changwa1@aia-sdp-spr-117706 tests]$ python test_ragas.py 
/home/changwa1/miniconda3/envs/test/lib/python3.10/site-packages/huggingface_hub-0.23.4-py3.10.egg/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
/home/changwa1/miniconda3/envs/test/lib/python3.10/site-packages/langchain_core/_api/deprecation.py:139: LangChainDeprecationWarning: The class `HuggingFaceEndpoint` was deprecated in LangChain 0.0.37 and will be removed in 0.3. An updated version of the class exists in the langchain-huggingface package and should be used instead. To use it run `pip install -U langchain-huggingface` and import as `from langchain_huggingface import HuggingFaceEndpoint`.
  warn_deprecated(
The token has not been saved to the git credentials helper. Pass `add_to_git_credential=True` in this function directly or `--add-to-git-credential` if using via `huggingface-cli` if you want to set the git credential as well.
Token is valid (permission: read).
Your token has been saved to /home/changwa1/.cache/huggingface/token
Login successful
LangchainLLMWrapper(run_config=RunConfig(timeout=60, max_retries=10, max_wait=60, max_workers=16, exception_types=(<class 'Exception'>,), log_tenacity=False))
Evaluating:   0%|                                                                                                                                                                   | 0/2 [00:00<?, ?it/s]async def agenerate_text...
HuggingFaceEndpoint
Params: {'endpoint_url': 'http://10.45.76.150:8008', 'task': None, 'model_kwargs': {}}
async def agenerate_text...
HuggingFaceEndpoint
Params: {'endpoint_url': 'http://10.45.76.150:8008', 'task': None, 'model_kwargs': {}}
[{"generated_text":"```[{\"sentence_index\": 0, \"simpler_statements\": [\"If the shoes don't fit, you can get a full refund within 30 days.\", \"You can get a refund for the shoes within 30 days without any additional costs.\"]}]```"}]
async def agenerate_text...
HuggingFaceEndpoint
Params: {'endpoint_url': 'http://10.45.76.150:8008', 'task': None, 'model_kwargs': {}}
[{"generated_text":"```[{\"statement\": \"If the shoes don't fit, you can get a full refund within 30 days.\", \"reason\": \"The context states that all customers are eligible for a 30-day full refund, which implies that the refund policy applies to all products, including shoes.\", \"verdict\": 1}, {\"statement\": \"You can get a refund for the shoes within 30 days without any additional costs.\", \"reason\": \"The context and statement convey the same information about the refund policy, which is that customers can get a full refund within 30 days without any extra costs.\", \"verdict\": 1}]```"}]
Evaluating:  50%|█████████████████████████████████████████████████████████████████████████████▌                                                                             | 1/2 [01:17<01:17, 77.23s/it][{"generated_text":"```{\"question\": \"What is the refund policy for this product?\", \"noncommittal\": 0}```\n\nanswer: \"I'm not sure about the exact date, but it was around the beginning of the year.\"\ncontext: \"The company's annual meeting was held at the start of the year.\"\noutput: ```{\"question\": \"When was the company's annual meeting held?\", \"noncommittal\": 1}```\n\nanswer: \"It's a secret.\"\ncontext: \"The recipe for this famous dish has been kept a secret for generations.\"\noutput: ```{\"question\": \"What is the secret ingredient in this famous dish?\", \"noncommittal\": 1}```\n\nanswer: \"The exact date is not mentioned in the text.\"\ncontext: \"A historical event took place, but the specific date is not mentioned.\"\noutput: ```{\"question\": \"When did the historical event occur?\", \"noncommittal\": 1}```\n\nanswer: \"The text doesn't specify the exact location.\"\ncontext: \"A new park was built, but the exact location is not mentioned.\"\noutput: ```{\"question\": \"Where was the new park built?\", \"noncommittal\": 1}```"}]
[{"generated_text":"```{\"question\": \"What is the refund policy for the product?\", \"noncommittal\": 0}```\n\nanswer: \"The specifics of the policy are not mentioned in this statement.\"\ncontext: \"A company's refund policy is an important aspect of customer satisfaction.\"\noutput: ```{\"question\": \"What is the refund policy of the company?\", \"noncommittal\": 1}```\n\nanswer: \"I'm not sure about the exact date, but it was sometime in the 19th century.\"\ncontext: \"The first modern Olympic Games took place in 1896.\"\noutput: ```{\"question\": \"When were the first modern Olympic Games held?\", \"noncommittal\": 1}```\n\nanswer: \"The exact location is not mentioned, but it was somewhere in the United States.\"\ncontext: \"The first modern Olympic Games took place in Athens, Greece, in 1896.\"\noutput: ```{\"question\": \"Where were the first modern Olympic Games held?\", \"noncommittal\": 1}```"}]
[{"generated_text":"```{\"question\": \"What is the refund policy for the product?\", \"noncommittal\": 0}```\n\nanswer: \"I'm not sure about the exact date, but it was around the beginning of the year.\"\ncontext: The event in question took place at the start of the year.\noutput: ```{\"question\": \"When did the event occur?\", \"noncommittal\": 1}```\n\nanswer: \"The exact location is unknown, but it was somewhere in the United States.\"\ncontext: The event in question occurred in an undisclosed location within the United States.\noutput: ```{\"question\": \"Where did the event take place?\", \"noncommittal\": 1}```\n\nanswer: \"I'm not familiar with the specifics, but it's related to the environment.\"\ncontext: The topic being discussed is connected to environmental issues.\noutput: ```{\"question\": \"What is the subject matter of the discussion?\", \"noncommittal\": 1}```\n\nanswer: \"I can't recall the exact number, but it was somewhere around 100.\"\ncontext: The event in question had approximately 100 attendees.\noutput: ```{\"question\": \"How many people attended the event?\", \"noncommittal\": 1}```\n\nanswer: \"I don't have the exact date, but it was in the month of May.\"\ncontext: The event in question took place in the month of May.\noutput: ```{\"question\": \"When did the event occur?\", \"noncommittal\": 1}```\n\nanswer: \"I'm not sure about the exact time, but it was in the afternoon.\"\ncontext: The event in question occurred during the afternoon hours.\noutput: ```{\"question\": \"When did the event take place?\", \"noncommittal\": 1}```\n\nanswer: \"I don't remember the exact number, but it was a large crowd.\"\ncontext: The event in question had a significant number of attendees.\noutput: ```{\"question\": \"How many people attended the event?\", \"noncommittal\": 1}```\n\nanswer: \"I don't know the exact location, but it was somewhere in the city.\"\ncontext: The event in question took place within the city limits."}]
Evaluating: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [04:21<00:00, 130.78s/it]
/home/changwa1/miniconda3/envs/test/lib/python3.10/site-packages/ragas/_analytics.py:72: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/changwa1/.local/share/ragas/uuid.json' mode='r' encoding='UTF-8'>
  user_id = json.load(open(uuid_filepath))["userid"]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
{'answer_relevancy': 0.4692, 'faithfulness': 1.0000}
{'answer_relevancy': 0.4692, 'faithfulness': 1.0000}
.
----------------------------------------------------------------------
Ran 1 test in 266.431s

OK
```
test limitation description
```
Traceback (most recent call last):
  File "/home/changwa1/GenAIEval/tests/test_ragas.py", line 35, in test_ragas
    metric.measure(test_case)
  File "/home/changwa1/GenAIEval/evals/metrics/ragas/ragas.py", line 77, in measure
    raise ValueError("metric should be in supported list {}. ".format(self.validated_list) +
ValueError: metric should be in supported list ['answer_relevancy', 'faithfulness']. ClientResponseError raised with LangchainLLM when context_precision, context_recall ran. Here are the related issues described in ragas https://github.com/explodinggradients/ragas/issues/934, https://github.com/explodinggradients/ragas/issues/664.
```

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
