### PR TITLE
Fix ut

### DIFF
--- a/tests/test_bigcode_eval.py
+++ b/tests/test_bigcode_eval.py
@@ -3,15 +3,15 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-#
-
 import unittest
 
+import transformers
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from evals.evaluation.bigcode_evaluation_harness import BigcodeEvalParser, evaluate
 
 
+@unittest.skipIf(transformers.__version__ > "4.41.2", "accuracy changed depends on transformers version.")
 class TestLMEval(unittest.TestCase):
     def test_lm_eval(self):
         model_name_or_path = "codeparrot/codeparrot-small"

--- a/tests/test_bigcode_eval.py
+++ b/tests/test_bigcode_eval.py
@@ -5,16 +5,14 @@
 
 import unittest
 
-import transformers
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from evals.evaluation.bigcode_evaluation_harness import BigcodeEvalParser, evaluate
 
 
-@unittest.skipIf(transformers.__version__ > "4.41.2", "accuracy changed depends on transformers version.")
 class TestLMEval(unittest.TestCase):
     def test_lm_eval(self):
-        model_name_or_path = "codeparrot/codeparrot-small"
+        model_name_or_path = "bigcode/tiny_starcoder_py"
         user_model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
         tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, truncation_side="left", padding_side="right")
         args = BigcodeEvalParser(

--- a/tests/test_lm_eval.py
+++ b/tests/test_lm_eval.py
@@ -3,8 +3,6 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-#
-
 import unittest
 
 from transformers import AutoModelForCausalLM, AutoTokenizer


### PR DESCRIPTION
## Description

"codeparrot/codeparrot-small" accuracy affected by transformers upgrade from 4.41.2 to 4.42.2, So change the ut test model to "bigcode/tiny_starcoder_py".

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
