### PR TITLE
doc: fix JSON example

### DIFF
--- a/evals/auto_tuning/README.md
+++ b/evals/auto_tuning/README.md
@@ -129,8 +129,6 @@ Example of a strategy file:
         "image": "opea/llm-tgi:latest",
         "replica": 4
     },
-
-    ... ...
     "reranking-dependency": {
         "type": "hpu",
         "image": "opea/tei-gaudi:latest",


### PR DESCRIPTION
Parsing the JSON example threw an error during the github.io doc build because of the ... content.  I removed the ... to remove the error. (You could also remove the JSON language name so it's not parsed as JSON.)

