### PR TITLE
doc: fix JSON example

### DIFF
--- a/evals/benchmark/auto_tuning/README.md
+++ b/evals/benchmark/auto_tuning/README.md
@@ -129,8 +129,6 @@ Example of a strategy file:
         "image": "opea/llm-tgi:latest",
         "replica": 4
     },
-
-    ... ...
     "reranking-dependency": {
         "type": "hpu",
         "image": "opea/tei-gaudi:latest",


### PR DESCRIPTION
When you mark a code-block as JSON, it must follow JSON syntax or it throws a warning when the github.io documents are built.  I removed the invalid `...`.
