### PR TITLE
fix bigcode version when python>=3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bigcode-eval@git+https://github.com/bigcode-project/bigcode-evaluation-harness.git@e5c2f31625223431d7987f43b70b75b9d26ba118
+bigcode-eval@git+https://github.com/bigcode-project/bigcode-evaluation-harness.git
 click
 deepdiff
 evaluate


### PR DESCRIPTION
## Description

fix bigcode install issue by update version when python >= 3.11

## Issues

https://github.com/opea-project/GenAIEval/issues/99