### PR TITLE
add bench-target as the prefix of output folder

### DIFF
--- a/evals/benchmark/stresscli/commands/load_test.py
+++ b/evals/benchmark/stresscli/commands/load_test.py
@@ -46,16 +46,17 @@ def locust_runtests(kubeconfig, profile):
         with open(profile, "r") as file:
             profile_data = yaml.safe_load(file)
 
-        # create test log folder
-        hostpath = profile_data["profile"]["storage"]["hostpath"]
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        base_folder = os.path.join(hostpath, f"{timestamp}")
-        os.makedirs(base_folder, exist_ok=True)
-
-        # Extract storage path and run details from profile
         global_settings = profile_data["profile"]["global-settings"]
         runs = profile_data["profile"]["runs"]
 
+        # create test log folder
+        hostpath = profile_data["profile"]["storage"]["hostpath"]
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        testtarget = global_settings.get("bench-target", locust_defaults["bench-target"])
+        base_folder = os.path.join(hostpath, f"{testtarget}_{timestamp}")
+        os.makedirs(base_folder, exist_ok=True)
+
+        # Extract storage path and run details from profile
         index = 1
         for run in runs:
             print(f"===Starting test: {run['name']}")


### PR DESCRIPTION
## Description

add bench-target as the prefix of output folder, in order to easily understand the test case of the output

## Issues

Currently, all output folders are in timestamp format. When testing with multiple endpoints, it's very hard to understand which test cases output folder is. Adding the bench-target can easily separate different test cases.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

n/a

## Tests

n/a
