### PR TITLE
doc: fix missing references to README.md

### DIFF
--- a/LEGAL_INFORMATION.md
+++ b/LEGAL_INFORMATION.md
@@ -9,7 +9,7 @@ Generative AI Evaluation is licensed under [Apache License Version 2.0](http://w
 This software includes components that have separate copyright notices and licensing terms.
 Your use of the source code for these components is subject to the terms and conditions of the following licenses.
 
-See the accompanying [license](/LICENSE) file for full license text and copyright notices.
+See the accompanying [license](LICENSE) file for full license text and copyright notices.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ results = evaluate(args)
 
 #### remote service usage
 
-1. setup a separate server with [GenAIComps](https://github.com/opea-project/GenAIComps/tree/main/comps/llms/utils/lm-eval)
+1. setup a separate server with [GenAIComps](https://github.com/opea-project/GenAIComps/tree/main/comps/llms/utils/lm-eval/README.md)
 
    ```
    # build cpu docker
@@ -172,4 +172,4 @@ Prometheus metrics collected during the tests can be used to create Grafana dash
 - [Code of Conduct](https://github.com/opea-project/docs/tree/main/community/CODE_OF_CONDUCT.md)
 - [Contribution](https://github.com/opea-project/docs/tree/main/community/CONTRIBUTING.md)
 - [Security Policy](https://github.com/opea-project/docs/tree/main/community/SECURITY.md)
-- [Legal Information](/LEGAL_INFORMATION.md)
+- [Legal Information](LEGAL_INFORMATION.md)

--- a/doc/platform-optimization/README.md
+++ b/doc/platform-optimization/README.md
@@ -94,7 +94,7 @@ kubectl edit balloonspolicy default
 ```
 
 Let us consider isolating AI inference and reranking containers in
-[ChatQnA](https://github.com/opea-project/GenAIExamples/tree/main/ChatQnA)
+[ChatQnA](https://github.com/opea-project/GenAIExamples/tree/main/ChatQnA/README.md)
 application's Gaudi accelerated pipeline.
 
 In the

--- a/evals/evaluation/agent_eval/crag_eval/README.md
+++ b/evals/evaluation/agent_eval/crag_eval/README.md
@@ -53,8 +53,10 @@ bash run_sample_data.sh
 ```
 
 ## Launch agent QnA system
-Here we showcase a RAG agent in GenAIExample repo. Please refer to the README in the [AgentQnA example](https://github.com/opea-project/GenAIExamples/tree/main/AgentQnA) for more details. </br>
-**Please note**: This is an example. You can build your own agent systems using OPEA components, then expose your own systems as an endpoint for this benchmark.</br>
+Here we showcase a RAG agent in GenAIExample repo. Please refer to the README in the [AgentQnA example](https://github.com/opea-project/GenAIExamples/tree/main/AgentQnA/README.md) for more details.
+
+> **Please note**: This is an example. You can build your own agent systems using OPEA components, then expose your own systems as an endpoint for this benchmark.
+
 To launch the agent in our AgentQnA example, open another terminal and build images and launch agent system there.
 1. Build images
 ```


### PR DESCRIPTION
Cross-repo references using an URL that only has the folder name cause links in the github.io site to go to the github.com site.  Most of these uses want to link to the documentation (README.md) so add that where appropriate so links in the github.io site stay there.
