### PR TITLE
Raise the error if importing bench target fails.

### DIFF
--- a/evals/benchmark/stresscli/locust/aistress.py
+++ b/evals/benchmark/stresscli/locust/aistress.py
@@ -225,10 +225,9 @@ def on_locust_init(environment, **_kwargs):
     os.environ["OPEA_EVAL_PROMPTS"] = environment.parsed_options.prompts
     os.environ["OPEA_EVAL_MAX_OUTPUT_TOKENS"] = str(environment.parsed_options.max_output)
     os.environ["LLM_MODEL"] = environment.parsed_options.llm_model
-    try:
-        bench_package = __import__(environment.parsed_options.bench_target)
-    except ImportError:
-        return None
+
+    bench_package = __import__(environment.parsed_options.bench_target)
+
     if not isinstance(environment.runner, WorkerRunner):
         gevent.spawn(checker, environment)
         environment.runner.register_message("worker_reqdata", on_reqdata)


### PR DESCRIPTION
## Description

When the import error of bench target occurs, the GenAIEval hangs until the test wall time(60 mins by default) is reached. So we need to raise the error to abort the test with exceptions in time.

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
