### PR TITLE
Fix chatqna pubmed benchmark issues.

### DIFF
--- a/evals/benchmark/stresscli/locust/chatqna_qlist_pubmed.py
+++ b/evals/benchmark/stresscli/locust/chatqna_qlist_pubmed.py
@@ -115,11 +115,11 @@ def getReqData():
     doc = getRandomDocument()
     message = f"{doc['title']}{prompt_suffix}"
     logging.debug(f"Selected document: {message}")
-    return {"messages": f"{message}", "max_tokens": int(MAX_TOKENS)}
+    return {"messages": f"{message}", "max_tokens": int(MAX_TOKENS), "top_k": 1, "temperature": 0}
 
 
-def respStatics(environment, resp):
-    return token.respStatics(environment, resp)
+def respStatics(environment, reqData, respData):
+    return token.respStatics(environment, reqData, respData)
 
 
 def staticsOutput(environment, reqlist):

--- a/evals/benchmark/stresscli/locust/tokenresponse.py
+++ b/evals/benchmark/stresscli/locust/tokenresponse.py
@@ -15,7 +15,7 @@ def testFunc():
 
 def respStatics(environment, req, resp):
     tokenizer = transformers.AutoTokenizer.from_pretrained(environment.parsed_options.llm_model)
-    if environment.parsed_options.bench_target in ["chatqnafixed", "chatqnabench", "faqgenfixed", "faqgenbench"]:
+    if environment.parsed_options.bench_target in ["chatqnafixed", "chatqnabench", "faqgenfixed", "faqgenbench", "chatqna_qlist_pubmed"]:
         num_token_input_prompt = len(tokenizer.encode(req["messages"]))
     elif environment.parsed_options.bench_target in ["llmfixed"]:
         num_token_input_prompt = len(tokenizer.encode(req["query"]))

--- a/evals/benchmark/stresscli/locust/tokenresponse.py
+++ b/evals/benchmark/stresscli/locust/tokenresponse.py
@@ -15,7 +15,13 @@ def testFunc():
 
 def respStatics(environment, req, resp):
     tokenizer = transformers.AutoTokenizer.from_pretrained(environment.parsed_options.llm_model)
-    if environment.parsed_options.bench_target in ["chatqnafixed", "chatqnabench", "faqgenfixed", "faqgenbench", "chatqna_qlist_pubmed"]:
+    if environment.parsed_options.bench_target in [
+        "chatqnafixed",
+        "chatqnabench",
+        "faqgenfixed",
+        "faqgenbench",
+        "chatqna_qlist_pubmed",
+    ]:
         num_token_input_prompt = len(tokenizer.encode(req["messages"]))
     elif environment.parsed_options.bench_target in ["llmfixed"]:
         num_token_input_prompt = len(tokenizer.encode(req["query"]))


### PR DESCRIPTION
## Description

1. modify respStatics function parameters
2. support chatqna_qlist_pubmed bench_target for input token calculation.

## Issues

Benchmark of ChatQnA on pubmed dataset failed for wrong function parameters.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

None

## Tests

Local tested on k8s.
