### PR TITLE
fix the error  of TTFT and TPOT while the bench target is chatqna_qlist_pubmed

### DIFF
--- a/evals/benchmark/stresscli/locust/aistress.py
+++ b/evals/benchmark/stresscli/locust/aistress.py
@@ -119,7 +119,7 @@ class AiStressUser(HttpUser):
             "codegenbench",
             "faqgenfixed",
             "faqgenbench",
-            "chatqna_qlist_pubmed"
+            "chatqna_qlist_pubmed",
         ]
         if self.environment.parsed_options.bench_target in ["faqgenfixed", "faqgenbench"]:
             req_params = {"data": reqData}

--- a/evals/benchmark/stresscli/locust/aistress.py
+++ b/evals/benchmark/stresscli/locust/aistress.py
@@ -119,6 +119,7 @@ class AiStressUser(HttpUser):
             "codegenbench",
             "faqgenfixed",
             "faqgenbench",
+            "chatqna_qlist_pubmed"
         ]
         if self.environment.parsed_options.bench_target in ["faqgenfixed", "faqgenbench"]:
             req_params = {"data": reqData}


### PR DESCRIPTION
## Description
missing streaming config of chatqna_qlist_pubmed
Lack of the config will cause the error of "next token latency"

example
```
End to End latency(ms),    P50: 25875.62,   P90: 34988.45,   P99: 56357.57,   Avg: 26382.29
Time to First Token-TTFT(ms),   P50: 25875.21,   P90: 34987.96,   P99: 56357.17,   Avg: 26381.87
Time Per Output Token-TPOT(ms),   P50: 0.00,   P90: 0.00,   P99: 0.01,   Avg: 0.00
```


## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
1. deploy the chatqna v1.2 
2. git pull the evel code
3.use locust command line to verify bench-target "chatqna_qlist_pubmed"
```
locust --locustfile ~/GenAIEval/evals/benchmark/stresscli/locust/aistress.py --host http://IP:PORT --run-time 60m  --max-output 128  --seed 1024 --processes 8 --users 128 --spawn-rate 100 --max-request 640 --bench-target chatqna_qlist_pubmed --llm-model meta-llama/Meta-Llama-3-8B-Instruct --stop-timeout 120 --csv /opt/opea/test_reports/test_locust/ --headless --only-summary --loglevel WARNING --json
```