### PR TITLE
Fix Grafana Dashboard datasource issue by removing uid dependency

### DIFF
--- a/evals/benchmark/grafana/chatqna_megaservice_grafana.json
+++ b/evals/benchmark/grafana/chatqna_megaservice_grafana.json
@@ -54,10 +54,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -140,10 +137,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "rate(process_cpu_seconds_total{job=\"$job_name\"}[1m])",
@@ -162,10 +156,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -247,10 +238,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "process_resident_memory_bytes{job=\"$job_name\"}",
@@ -269,10 +257,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -356,10 +341,7 @@
       "targets": [
         {
           "$$hashKey": "object:214",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "expr": "sum by(handler) (rate(http_requests_total{job=\"$job_name\", handler!~\"/metrics|/v1/health_check|none\"}[1m]))",
@@ -378,10 +360,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -496,10 +475,7 @@
       "targets": [
         {
           "$$hashKey": "object:140",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "sum by(status) (rate(http_requests_total{job=\"$job_name\"}[1m]))",
@@ -518,10 +494,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -621,10 +594,7 @@
       "targets": [
         {
           "$$hashKey": "object:766",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "sum(rate(http_requests_total{status=\"5xx\", job=\"$job_name\"}[30s]))",
@@ -643,10 +613,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -733,10 +700,7 @@
       "targets": [
         {
           "$$hashKey": "object:426",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "expr": "histogram_quantile(0.$Percentage, rate(http_request_duration_seconds_bucket{job=\"$job_name\", handler!~\"/metrics|/v1/health_check|none\"}[1m])) ",
@@ -755,10 +719,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -843,10 +804,7 @@
       "targets": [
         {
           "$$hashKey": "object:146",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "http_request_duration_seconds_sum{handler!=\"none\",job=\"$job_name\", handler!~\"/metrics|/v1/health_check|none\"} / http_request_duration_seconds_count",
           "format": "time_series",
@@ -868,10 +826,7 @@
     "list": [
       {
         "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "definition": "label_values(http_requests_total{},job)",
         "hide": 0,
         "includeAll": false,

--- a/evals/benchmark/grafana/cpu_grafana.json
+++ b/evals/benchmark/grafana/cpu_grafana.json
@@ -1343,7 +1343,7 @@
         {
           "allValue": null,
           "current": {},
-          "datasource": "${DS_HOME_MAIN PROMETHEUS}",
+          "datasource": "Prometheus",
           "definition": "label_values(node_boot_time_seconds, instance)",
           "hide": 0,
           "includeAll": false,
@@ -1471,7 +1471,7 @@
         {
           "allValue": null,
           "current": {},
-          "datasource": "${DS_HOME_MAIN PROMETHEUS}",
+          "datasource": "Prometheus",
           "definition": "label_values(node_cpu_seconds_total, cpu)",
           "hide": 0,
           "includeAll": true,

--- a/evals/benchmark/grafana/dataprep_microservice_grafana.json
+++ b/evals/benchmark/grafana/dataprep_microservice_grafana.json
@@ -23,10 +23,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -109,10 +106,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "rate(process_cpu_seconds_total{container=\"$container_name\"}[1m])",
@@ -131,10 +125,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -216,10 +207,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "process_resident_memory_bytes{container=\"$container_name\"}",
@@ -238,10 +226,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -325,10 +310,7 @@
       "targets": [
         {
           "$$hashKey": "object:214",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "expr": "sum by(handler) (rate(http_requests_total{container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"}[1m]))",
@@ -347,10 +329,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -465,10 +444,7 @@
       "targets": [
         {
           "$$hashKey": "object:140",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "sum by(status) (rate(http_requests_total{container=\"$container_name\"}[1m]))",
@@ -487,10 +463,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -590,10 +563,7 @@
       "targets": [
         {
           "$$hashKey": "object:766",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "sum(rate(http_requests_total{status=\"5xx\", container=\"$container_name\"}[30s]))",
@@ -612,10 +582,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -702,10 +669,7 @@
       "targets": [
         {
           "$$hashKey": "object:426",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "expr": "histogram_quantile(0.$Percentage, rate(http_request_duration_seconds_bucket{container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"}[1m])) ",
@@ -724,10 +688,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -812,10 +773,7 @@
       "targets": [
         {
           "$$hashKey": "object:146",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "http_request_duration_seconds_sum{handler!=\"none\",container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"} / http_request_duration_seconds_count",
           "format": "time_series",
@@ -841,10 +799,7 @@
           "text": "dataprep-microservice",
           "value": "dataprep-microservice"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
+        "datasource": "Prometheus",
         "definition": "label_values(http_requests_total{namespace=\"opea-rag\"},container)",
         "hide": 0,
         "includeAll": false,

--- a/evals/benchmark/grafana/embedding_microservice_grafana.json
+++ b/evals/benchmark/grafana/embedding_microservice_grafana.json
@@ -23,10 +23,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -109,10 +106,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "rate(process_cpu_seconds_total{container=\"$container_name\"}[1m])",
@@ -131,10 +125,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -216,10 +207,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "process_resident_memory_bytes{container=\"$container_name\"}",
@@ -238,10 +226,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -325,10 +310,7 @@
       "targets": [
         {
           "$$hashKey": "object:214",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "expr": "sum by(handler) (rate(http_requests_total{container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"}[1m]))",
@@ -347,10 +329,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -465,10 +444,7 @@
       "targets": [
         {
           "$$hashKey": "object:140",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "sum by(status) (rate(http_requests_total{container=\"$container_name\"}[1m]))",
@@ -487,10 +463,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -590,10 +563,7 @@
       "targets": [
         {
           "$$hashKey": "object:766",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "sum(rate(http_requests_total{status=\"5xx\", container=\"$container_name\"}[30s]))",
@@ -612,10 +582,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -702,10 +669,7 @@
       "targets": [
         {
           "$$hashKey": "object:426",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "expr": "histogram_quantile(0.$Percentage, rate(http_request_duration_seconds_bucket{container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"}[1m])) ",
@@ -724,10 +688,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -812,10 +773,7 @@
       "targets": [
         {
           "$$hashKey": "object:146",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "http_request_duration_seconds_sum{handler!=\"none\",container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"} / http_request_duration_seconds_count",
           "format": "time_series",
@@ -841,10 +799,7 @@
           "text": "embedding-microservice",
           "value": "embedding-microservice"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
+        "datasource": "Prometheus",
         "definition": "label_values(http_requests_total{namespace=\"opea-rag\"},container)",
         "hide": 0,
         "includeAll": false,

--- a/evals/benchmark/grafana/gaudi_grafana.json
+++ b/evals/benchmark/grafana/gaudi_grafana.json
@@ -46,10 +46,7 @@
       "list": [
         {
           "builtIn": 1,
-          "datasource": {
-            "type": "datasource",
-            "uid": "grafana"
-          },
+          "datasource": "Prometheus",
           "enable": true,
           "hide": true,
           "iconColor": "rgba(0, 211, 255, 1)",
@@ -67,10 +64,7 @@
     "links": [],
     "panels": [
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "",
         "fieldConfig": {
           "defaults": {
@@ -122,10 +116,7 @@
         "pluginVersion": "11.0.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": true,
             "expr": "habanalabs_device_config{instance=\"$node\", UUID=\"$hpu\"}",
@@ -147,10 +138,7 @@
         "type": "stat"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "",
         "fieldConfig": {
           "defaults": {
@@ -207,10 +195,7 @@
         "pluginVersion": "11.0.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": false,
             "expr": "habanalabs_utilization{instance=\"$node\", UUID=\"$hpu\"}/100",
@@ -234,10 +219,7 @@
         "type": "gauge"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "",
         "fieldConfig": {
           "defaults": {
@@ -290,10 +272,7 @@
         "pluginVersion": "11.0.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": true,
             "expr": "habanalabs_power_mW{instance=\"$node\", UUID=\"$hpu\"}",
@@ -316,10 +295,7 @@
         "type": "gauge"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "PCIe Throughput.",
         "fieldConfig": {
           "defaults": {
@@ -396,10 +372,7 @@
         "pluginVersion": "11.1.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": false,
             "expr": "habanalabs_pcie_receive_throughput{UUID=\"$hpu\", instance=\"$node\"}",
@@ -411,10 +384,7 @@
             "refId": "A"
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": false,
             "expr": "habanalabs_pcie_transmit_throughput{UUID=\"$hpu\", instance=\"$node\"}",
@@ -438,10 +408,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "onchip temperature. in degrees C.",
         "fieldConfig": {
           "defaults": {
@@ -498,10 +465,7 @@
         "pluginVersion": "11.0.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": true,
             "expr": "habanalabs_temperature_onchip{UUID=\"$hpu\", instance=\"$node\"}",
@@ -516,10 +480,7 @@
         "type": "gauge"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "onboard temperature. in degrees C.",
         "fieldConfig": {
           "defaults": {
@@ -576,10 +537,7 @@
         "pluginVersion": "11.0.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": true,
             "expr": "habanalabs_temperature_onboard{UUID=\"$hpu\", instance=\"$node\"}",
@@ -594,10 +552,7 @@
         "type": "gauge"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "The BIOS of the hpu board.",
         "fieldConfig": {
           "defaults": {
@@ -649,10 +604,7 @@
         "pluginVersion": "11.0.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": true,
             "expr": "habanalabs_device_config{instance=\"$node\", UUID=\"$hpu\"}",
@@ -674,10 +626,7 @@
         "type": "stat"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "The Firmware of the HPU board.",
         "fieldConfig": {
           "defaults": {
@@ -729,10 +678,7 @@
         "pluginVersion": "11.0.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": true,
             "expr": "habanalabs_device_config{instance=\"$node\", UUID=\"$hpu\"}",
@@ -754,10 +700,7 @@
         "type": "stat"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "",
         "fieldConfig": {
           "defaults": {
@@ -835,10 +778,7 @@
         "pluginVersion": "11.1.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": true,
             "expr": "habanalabs_utilization{instance=\"$node\", UUID=\"$hpu\"}/100",
@@ -861,10 +801,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "Core hpu temperature. in degrees C.",
         "fieldConfig": {
           "defaults": {
@@ -942,10 +879,7 @@
         "pluginVersion": "11.1.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": false,
             "expr": "habanalabs_temperature_onboard{UUID=\"$hpu\", instance=\"$node\"}",
@@ -957,10 +891,7 @@
             "refId": "A"
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": false,
             "expr": "habanalabs_temperature_onchip{UUID=\"$hpu\", instance=\"$node\"}",
@@ -984,10 +915,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "",
         "fieldConfig": {
           "defaults": {
@@ -1039,10 +967,7 @@
         "pluginVersion": "11.0.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "expr": "habanalabs_clock_soc_mhz{UUID=\"$hpu\", instance=\"$node\"}",
             "format": "table",
@@ -1057,10 +982,7 @@
         "type": "stat"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "Total memory allocated by active contexts.",
         "fieldConfig": {
           "defaults": {
@@ -1141,10 +1063,7 @@
         "pluginVersion": "11.1.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": true,
             "expr": "habanalabs_memory_used_bytes{UUID=\"$hpu\", instance=\"$node\"}",
@@ -1167,10 +1086,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "",
         "fieldConfig": {
           "defaults": {
@@ -1251,10 +1167,7 @@
         "pluginVersion": "11.1.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "exemplar": true,
             "expr": "habanalabs_power_mW{instance=\"$node\", UUID=\"$hpu\"}",
@@ -1277,10 +1190,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "description": "",
         "fieldConfig": {
           "defaults": {
@@ -1358,10 +1268,7 @@
         "pluginVersion": "11.1.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
+            "datasource": "Prometheus",
             "disableTextWrap": false,
             "editorMode": "code",
             "exemplar": true,
@@ -1399,10 +1306,7 @@
       "list": [
         {
           "current": {},
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "definition": "label_values(habanalabs_kube_info,hostname)",
           "hide": 0,
           "includeAll": false,
@@ -1426,10 +1330,7 @@
         },
         {
           "current": {},
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "definition": "label_values(habanalabs_device_config{instance=\"$node\"},UUID)",
           "hide": 0,
           "includeAll": false,

--- a/evals/benchmark/grafana/qdrant_grafana.json
+++ b/evals/benchmark/grafana/qdrant_grafana.json
@@ -29,10 +29,7 @@
     "liveNow": false,
     "panels": [
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P4169E866C3094E38"
-        },
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "mappings": [],
@@ -77,10 +74,7 @@
         "pluginVersion": "9.3.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P4169E866C3094E38"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "expr": "app_info{job=\"qdrant\"}",
             "legendFormat": "{{ version }}",
@@ -92,10 +86,7 @@
         "type": "stat"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P4169E866C3094E38"
-        },
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -142,10 +133,7 @@
         "pluginVersion": "9.3.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P4169E866C3094E38"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "expr": "collections_total{job=\"qdrant\"}",
             "legendFormat": "collection_total",
@@ -157,10 +145,7 @@
         "type": "stat"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P4169E866C3094E38"
-        },
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -207,10 +192,7 @@
         "pluginVersion": "9.3.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P4169E866C3094E38"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "expr": "cluster_peers_total{job=\"qdrant\"}",
             "legendFormat": "cluster_peers_total",
@@ -222,10 +204,7 @@
         "type": "stat"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P4169E866C3094E38"
-        },
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -272,10 +251,7 @@
         "pluginVersion": "9.3.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P4169E866C3094E38"
-            },
+            "datasource": "Prometheus",
             "editorMode": "builder",
             "expr": "cluster_term{job=\"qdrant\"}",
             "legendFormat": "cluster term",
@@ -287,10 +263,7 @@
         "type": "stat"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P4169E866C3094E38"
-        },
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -337,10 +310,7 @@
         "pluginVersion": "9.3.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P4169E866C3094E38"
-            },
+            "datasource": "Prometheus",
             "editorMode": "builder",
             "expr": "cluster_commit{job=\"qdrant\"}",
             "legendFormat": "cluster_commit",
@@ -352,10 +322,7 @@
         "type": "stat"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P4169E866C3094E38"
-        },
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -429,10 +396,7 @@
         },
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P4169E866C3094E38"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "expr": "rate(cluster_pending_operations_total{job=\"qdrant\"}[5m])",
             "legendFormat": "cluster_pending_operations_total",
@@ -444,10 +408,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P4169E866C3094E38"
-        },
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -522,10 +483,7 @@
         "pluginVersion": "9.3.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P4169E866C3094E38"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "expr": "collections_vector_total{job=\"qdrant\"}",
             "legendFormat": "collections_vector_total",
@@ -537,10 +495,7 @@
         "type": "timeseries"
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P4169E866C3094E38"
-        },
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -615,10 +570,7 @@
         },
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P4169E866C3094E38"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "expr": "rest_responses_total{job=\"qdrant\", exported_endpoint=\"/collections/{name}/points\", method=\"PUT\"}",
             "legendFormat": "{{label_name}}",
@@ -626,10 +578,7 @@
             "refId": "A"
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P4169E866C3094E38"
-            },
+            "datasource": "Prometheus",
             "editorMode": "code",
             "expr": "rest_responses_total{job=\"qdrant\", exported_endpoint=\"/collections/{name}/points/search\", method=\"POST\"}",
             "hide": false,

--- a/evals/benchmark/grafana/redis_grafana.json
+++ b/evals/benchmark/grafana/redis_grafana.json
@@ -78,7 +78,7 @@
     "panels": [
       {
         "collapsed": false,
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "gridPos": {
           "h": 1,
           "w": 24,
@@ -99,7 +99,7 @@
         "type": "row"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -184,7 +184,7 @@
         "type": "stat"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -281,7 +281,7 @@
         "type": "gauge"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -441,7 +441,7 @@
         "type": "bargauge"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -518,7 +518,7 @@
         "type": "stat"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {},
@@ -593,7 +593,7 @@
         "type": "stat"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -668,7 +668,7 @@
         "type": "stat"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -730,7 +730,7 @@
         "type": "stat"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -818,7 +818,7 @@
         "type": "bargauge"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -906,7 +906,7 @@
         "type": "bargauge"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -983,7 +983,7 @@
       },
       {
         "collapsed": false,
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "gridPos": {
           "h": 1,
           "w": 24,
@@ -1004,7 +1004,7 @@
         "type": "row"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -1144,7 +1144,7 @@
         "type": "table"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -1295,7 +1295,7 @@
         "type": "table"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -1434,7 +1434,7 @@
       },
       {
         "collapsed": false,
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "gridPos": {
           "h": 1,
           "w": 24,
@@ -1447,7 +1447,7 @@
         "type": "row"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -1518,7 +1518,7 @@
         "type": "stat"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -1590,7 +1590,7 @@
         "type": "stat"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -1668,7 +1668,7 @@
         "type": "bargauge"
       },
       {
-        "datasource": "${DS_REDIS}",
+        "datasource": "Prometheus",
         "fieldConfig": {
           "defaults": {
             "custom": {

--- a/evals/benchmark/grafana/rerank_microservice_grafana.json
+++ b/evals/benchmark/grafana/rerank_microservice_grafana.json
@@ -23,10 +23,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -109,10 +106,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "rate(process_cpu_seconds_total{container=\"$container_name\"}[1m])",
@@ -131,10 +125,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -216,10 +207,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "process_resident_memory_bytes{container=\"$container_name\"}",
@@ -238,10 +226,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -325,10 +310,7 @@
       "targets": [
         {
           "$$hashKey": "object:214",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "expr": "sum by(handler) (rate(http_requests_total{container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"}[1m]))",
@@ -347,10 +329,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -465,10 +444,7 @@
       "targets": [
         {
           "$$hashKey": "object:140",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "sum by(status) (rate(http_requests_total{container=\"$container_name\"}[1m]))",
@@ -487,10 +463,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -590,10 +563,7 @@
       "targets": [
         {
           "$$hashKey": "object:766",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "sum(rate(http_requests_total{status=\"5xx\", container=\"$container_name\"}[30s]))",
@@ -612,10 +582,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -702,10 +669,7 @@
       "targets": [
         {
           "$$hashKey": "object:426",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "expr": "histogram_quantile(0.$Percentage, rate(http_request_duration_seconds_bucket{container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"}[1m])) ",
@@ -724,10 +688,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -812,10 +773,7 @@
       "targets": [
         {
           "$$hashKey": "object:146",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "http_request_duration_seconds_sum{handler!=\"none\",container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"} / http_request_duration_seconds_count",
           "format": "time_series",
@@ -841,10 +799,7 @@
           "text": "reranking-microservice",
           "value": "reranking-microservice"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
+        "datasource": "Prometheus",
         "definition": "label_values(http_requests_total{namespace=\"opea-rag\"},container)",
         "hide": 0,
         "includeAll": false,

--- a/evals/benchmark/grafana/retrieval_microservice_grafana.json
+++ b/evals/benchmark/grafana/retrieval_microservice_grafana.json
@@ -23,10 +23,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -109,10 +106,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "rate(process_cpu_seconds_total{container=\"$container_name\"}[1m])",
@@ -131,10 +125,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -216,10 +207,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "process_resident_memory_bytes{container=\"$container_name\"}",
@@ -238,10 +226,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -325,10 +310,7 @@
       "targets": [
         {
           "$$hashKey": "object:214",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "expr": "sum by(handler) (rate(http_requests_total{container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"}[1m]))",
@@ -347,10 +329,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -465,10 +444,7 @@
       "targets": [
         {
           "$$hashKey": "object:140",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "sum by(status) (rate(http_requests_total{container=\"$container_name\"}[1m]))",
@@ -487,10 +463,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -590,10 +563,7 @@
       "targets": [
         {
           "$$hashKey": "object:766",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "sum(rate(http_requests_total{status=\"5xx\", container=\"$container_name\"}[30s]))",
@@ -612,10 +582,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -702,10 +669,7 @@
       "targets": [
         {
           "$$hashKey": "object:426",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "expr": "histogram_quantile(0.$Percentage, rate(http_request_duration_seconds_bucket{container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"}[1m])) ",
@@ -724,10 +688,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -812,10 +773,7 @@
       "targets": [
         {
           "$$hashKey": "object:146",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "e4584a9f-5364-4b3d-a851-7abbc5250820"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "http_request_duration_seconds_sum{handler!=\"none\",container=\"$container_name\", handler!~\"/metrics|/v1/health_check|none\"} / http_request_duration_seconds_count",
           "format": "time_series",
@@ -841,10 +799,7 @@
           "text": "retrieval-microservice",
           "value": "retrieval-microservice"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
+        "datasource": "Prometheus",
         "definition": "label_values(http_requests_total{namespace=\"opea-rag\"},container)",
         "hide": 0,
         "includeAll": false,

--- a/evals/benchmark/grafana/tei_grafana.json
+++ b/evals/benchmark/grafana/tei_grafana.json
@@ -46,10 +46,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": "Prometheus",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -87,10 +84,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -171,10 +165,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "sum(increase(te_embed_success{namespace=\"\", job=\"$job\"}[1m]))",
           "legendFormat": "Success",
@@ -182,10 +173,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "sum(increase(te_embed_count{namespace=\"\", job=\"$job\"}[1m]))",
           "hide": false,
@@ -198,10 +186,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -328,10 +313,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.5, sum by (le) (rate(te_embed_queue_duration_bucket{namespace=\"\", job=\"$job\"}[10m])))",
           "legendFormat": "p50",
@@ -339,10 +321,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.9, sum by (le) (rate(te_embed_queue_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -351,10 +330,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum by (le) (rate(te_embed_queue_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -377,10 +353,7 @@
         "mode": "opacity"
       },
       "dataFormat": "tsbuckets",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -455,10 +428,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "sum(increase(te_request_duration_bucket{namespace=\"\", job=\"$job\"}[5m])) by (le)",
@@ -487,10 +457,7 @@
       "yBucketBound": "auto"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -572,10 +539,7 @@
       "pluginVersion": "9.1.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "count(te_request_count{namespace=\"\", job=\"$job\"})",
           "legendFormat": "Replicas",
@@ -587,10 +551,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -639,10 +600,7 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "sum(te_queue_size{namespace=\"\", job=\"$job\"})",
           "legendFormat": "__auto",
@@ -654,10 +612,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -784,10 +739,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.5, sum by (le) (rate(te_embed_duration_bucket{namespace=\"\", job=\"$job\"}[10m])))",
           "legendFormat": "p50",
@@ -795,10 +747,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.9, sum by (le) (rate(te_embed_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -807,10 +756,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum by (le) (rate(te_embed_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -823,10 +769,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -953,10 +896,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.5, sum by (le) (rate(te_request_tokenization_duration_bucket{namespace=\"\", job=\"$job\"}[10m])))",
           "legendFormat": "p50",
@@ -964,10 +904,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.9, sum by (le) (rate(te_request_tokenization_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -976,10 +913,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum by (le) (rate(te_request_tokenization_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -992,10 +926,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1122,10 +1053,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.5, sum by (le) (rate(te_request_inference_duration_bucket{namespace=\"\", job=\"$job\"}[10m])))",
           "legendFormat": "p50",
@@ -1133,10 +1061,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.9, sum by (le) (rate(te_request_inference_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -1145,10 +1070,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum by (le) (rate(te_request_inference_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -1161,10 +1083,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1291,10 +1210,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.5, sum by (le) (rate(te_embed_tokenization_duration_bucket{namespace=\"\", job=\"$job\"}[10m])))",
           "legendFormat": "p50",
@@ -1302,10 +1218,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.9, sum by (le) (rate(te_embed_tokenization_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -1314,10 +1227,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum by (le) (rate(te_embed_tokenization_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -1343,10 +1253,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1424,10 +1331,7 @@
       "pluginVersion": "9.1.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "avg(te_batch_next_size_bucket{namespace=\"\", job=\"$job\"})",
           "legendFormat": "{{ pod }}",
@@ -1439,10 +1343,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1568,10 +1469,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.5, sum by (le) (rate(te_request_queue_duration_bucket{namespace=\"\", job=\"$job\"}[10m])))",
           "legendFormat": "p50",
@@ -1579,10 +1477,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.9, sum by (le) (rate(te_request_queue_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -1591,10 +1486,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum by (le) (rate(te_request_queue_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -1607,10 +1499,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1688,10 +1577,7 @@
       "pluginVersion": "9.1.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "avg(te_request_input_length_bucket{namespace=\"\", job=\"$job\"})",
           "legendFormat": "{{ pod }}",
@@ -1716,10 +1602,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1845,10 +1728,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.5, sum by (le) (rate(te_embed_inference_duration_bucket{method=\"\", namespace=\"\", job=\"$job\"}[10m])))",
           "legendFormat": "p50",
@@ -1856,10 +1736,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.9, sum by (le) (rate(te_embed_inference_duration_bucket{method=\"\", namespace=\"\", job=\"$job\"}[10m])))",
           "hide": false,
@@ -1868,10 +1745,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum by (le) (rate(te_embed_inference_duration_bucket{method=\"\", namespace=\"\", job=\"$job\"}[10m])))",
           "hide": false,
@@ -1894,10 +1768,7 @@
         "mode": "opacity"
       },
       "dataFormat": "tsbuckets",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -1972,10 +1843,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "sum(increase(te_embed_inference_duration_bucket{method=\"\", namespace=\"\", job=\"$job\"}[5m])) by (le)",
@@ -2017,10 +1885,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2146,10 +2011,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.5, sum by (le) (rate(te_embed_inference_duration_bucket{namespace=\"\", job=\"$job\"}[10m])))",
           "legendFormat": "p50",
@@ -2157,10 +2019,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.9, sum by (le) (rate(te_embed_inference_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -2169,10 +2028,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum by (le) (rate(te_embed_inference_duration_bucket{job=\"$job\"}[10m])))",
           "hide": false,
@@ -2209,10 +2065,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "definition": "label_values(te_request_count,namespace)",
         "hide": 0,
         "includeAll": false,
@@ -2235,10 +2088,7 @@
           "text": "chatqna-tei",
           "value": "chatqna-tei"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "datasource": "Prometheus",
         "definition": "label_values(te_request_count{namespace=\"\"},job)",
         "hide": 0,
         "includeAll": false,


### PR DESCRIPTION
## Description

Got issues to see Grafana Dashboard for mega and micro services.
it should be caused by changing UID among systems.

We fixed by removing UID dependency following the suggestion from below post.
https://community.grafana.com/t/should-provisioned-dashboards-have-datasource-uids/65463/8

all dashboards work now based on the merged PR : https://github.com/opea-project/GenAIExamples/pull/1623

![image](https://github.com/user-attachments/assets/7f4a13d2-7aac-4c9b-86a6-7e9724cd4bf5)

![image](https://github.com/user-attachments/assets/741b4893-8f83-46ab-8f78-76b6635c36fb)


## Issues

[Issue#247](https://github.com/opea-project/GenAIEval/issues/247)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

NA

## Tests

Manually test
