### PR TITLE
Restrict numpy version to below 2.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ langchain_community
 langchain_huggingface
 lm-eval==0.4.3
 locust
-numpy
+numpy < 2.0
 prometheus_client
 pytest
 pyyaml


### PR DESCRIPTION
## Description

Restrict numpy version to below 2.0 in requirements.txt

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

CI
