### PR TITLE
Added docsumfixed to streaming_bench_target and changed variable name

### DIFF
--- a/evals/benchmark/stresscli/locust/aistress.py
+++ b/evals/benchmark/stresscli/locust/aistress.py
@@ -144,6 +144,7 @@ class AiStressUser(HttpUser):
             "codegenfixed",
             "codegenbench",
             "docsumbench",
+            "docsumfixed",
             "faqgenfixed",
             "faqgenbench",
             "chatqna_qlist_pubmed",

--- a/evals/benchmark/stresscli/locust/docsumbench.py
+++ b/evals/benchmark/stresscli/locust/docsumbench.py
@@ -8,7 +8,7 @@ import tokenresponse as token
 cwd = os.path.dirname(__file__)
 filepath = os.environ["OPEA_EVAL_DATASET"]
 filename = os.path.basename(filepath)
-max_tokens = os.environ["OPEA_EVAL_MAX_NEW_TOKENS"]
+max_tokens = os.environ["OPEA_EVAL_MAX_OUTPUT_TOKENS"]
 summary_type = os.environ["OPEA_EVAL_SUMMARY_TYPE"]
 stream = os.environ["OPEA_EVAL_STREAM"]
 

--- a/evals/benchmark/stresscli/locust/docsumfixed.py
+++ b/evals/benchmark/stresscli/locust/docsumfixed.py
@@ -8,7 +8,7 @@ import tokenresponse as token
 cwd = os.path.dirname(__file__)
 filepath = f"{cwd}/../../data/upload_file.txt"
 filename = os.path.basename(filepath)
-max_tokens = os.environ["OPEA_EVAL_MAX_NEW_TOKENS"]
+max_tokens = os.environ["OPEA_EVAL_MAX_OUTPUT_TOKENS"]
 
 
 def getUrl():


### PR DESCRIPTION
## Description

* Variable name changed to match ChatQnA variable name

## Issues

`n/a`.

## Type of change

- [x ] New feature (non-breaking change which adds new functionality)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Tested with deply_and_benchmark.py scripts from GenAIEval repo to test new benchmarking features for DocSum.
