### PR TITLE
Fix for Input/Output Token Count Calculation for specific GenAIExamples

### DIFF
--- a/evals/benchmark/stresscli/locust/aistress.py
+++ b/evals/benchmark/stresscli/locust/aistress.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import re
 import logging
 import os
+import re
 import sys
 import threading
 import time
@@ -253,8 +253,8 @@ class AiStressUser(HttpUser):
                                         complete_response += chunk
                                     match = re.search(r'"text":"(.*?)"', chunk)
                                     if match:
-                                        extracted_text = match.group(1) 
-                                        complete_response += extracted_text 
+                                        extracted_text = match.group(1)
+                                        complete_response += extracted_text
                         end_ts = time.perf_counter()
                         respData = {
                             "response_string": complete_response,

--- a/evals/benchmark/stresscli/locust/aistress.py
+++ b/evals/benchmark/stresscli/locust/aistress.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import re
 import logging
 import os
 import sys
@@ -249,7 +250,11 @@ class AiStressUser(HttpUser):
                                     chunk = event.data.strip()
                                     if chunk.startswith("b'") and chunk.endswith("'"):
                                         chunk = chunk[2:-1]
-                                complete_response += chunk
+                                        complete_response += chunk
+                                    match = re.search(r'"text":"(.*?)"', chunk)
+                                    if match:
+                                        extracted_text = match.group(1) 
+                                        complete_response += extracted_text 
                         end_ts = time.perf_counter()
                         respData = {
                             "response_string": complete_response,

--- a/evals/benchmark/stresscli/locust/aistress.py
+++ b/evals/benchmark/stresscli/locust/aistress.py
@@ -251,10 +251,17 @@ class AiStressUser(HttpUser):
                                     if chunk.startswith("b'") and chunk.endswith("'"):
                                         chunk = chunk[2:-1]
                                         complete_response += chunk
-                                    match = re.search(r'"text":"(.*?)"', chunk)
-                                    if match:
-                                        extracted_text = match.group(1)
-                                        complete_response += extracted_text
+                                    elif re.search(r'"type":"LLMResult"', chunk):
+                                        match = re.search(r'"text":"(.*?)"', chunk)
+                                        if match:
+                                            extracted_text = match.group(1)
+                                            complete_response += extracted_text
+                                        break
+                                    else:
+                                        match = re.search(r'"text":"(.*?)"', chunk)
+                                        if match:
+                                            extracted_text = match.group(1)
+                                            complete_response += extracted_text                                
                         end_ts = time.perf_counter()
                         respData = {
                             "response_string": complete_response,

--- a/evals/benchmark/stresscli/locust/aistress.py
+++ b/evals/benchmark/stresscli/locust/aistress.py
@@ -261,7 +261,7 @@ class AiStressUser(HttpUser):
                                         match = re.search(r'"text":"(.*?)"', chunk)
                                         if match:
                                             extracted_text = match.group(1)
-                                            complete_response += extracted_text                                
+                                            complete_response += extracted_text
                         end_ts = time.perf_counter()
                         respData = {
                             "response_string": complete_response,

--- a/evals/benchmark/stresscli/locust/tokenresponse.py
+++ b/evals/benchmark/stresscli/locust/tokenresponse.py
@@ -13,40 +13,81 @@ def testFunc():
     print("TestFunc from token_response")
 
 
-def respStatics(environment, req, resp):
-    if not hasattr(environment, "tokenizer"):
-        tokenizer = transformers.AutoTokenizer.from_pretrained(environment.parsed_options.llm_model)
-    else:
-        tokenizer = environment.tokenizer
+def respStatics(environment, req, resp):  
+    if not hasattr(environment, "tokenizer"):  
+        tokenizer = transformers.AutoTokenizer.from_pretrained(environment.parsed_options.llm_model)  
+    else:  
+        tokenizer = environment.tokenizer  
 
-    if environment.parsed_options.bench_target in [
-        "chatqnafixed",
-        "chatqnabench",
-        "faqgenfixed",
-        "faqgenbench",
-        "chatqna_qlist_pubmed",
-    ]:
-        num_token_input_prompt = len(tokenizer.encode(req["messages"]))
-    elif environment.parsed_options.bench_target in ["llmfixed"]:
-        num_token_input_prompt = len(tokenizer.encode(req["query"]))
-    elif environment.parsed_options.bench_target == "llmservefixed":
-        content = " ".join([msg["content"] for msg in req["messages"]])
-        num_token_input_prompt = len(tokenizer.encode(content))
-    else:
-        num_token_input_prompt = -1
+    if environment.parsed_options.bench_target in [  
+        "chatqnafixed",  
+        "chatqnabench",  
+        "codegenfixed", 
+        "faqgenfixed",  
+        "faqgenbench",  
+        "chatqna_qlist_pubmed",  
+    ]: 
+        num_token_input_prompt = len(tokenizer.encode(req["messages"]))  
+    elif environment.parsed_options.bench_target in [  
+        "codetransfixed",  
+    ]:  
+        import json  
+        req_str = json.dumps(req)  
+        num_token_input_prompt = len(tokenizer.encode(req_str))  
+    elif environment.parsed_options.bench_target in [  
+        "docsumfixed"  
+    ]:  
+        import re  
+        raw_response = resp["response_string"]  
+        input_matches = re.findall(r'"page_content":"(.*?)"', raw_response)  
+        output_matches = re.findall(r'"output_text":"(.*?)"', raw_response)  
+        if input_matches:  
+            last_input_text = input_matches[-1]  
+            num_token_input_prompt = len(tokenizer.encode(last_input_text))  
+        else:  
+            print("Error: 'input_text' not found in the response string.")  
+        if output_matches:  
+            last_output_text = output_matches[-1]  
+            num_token_output = len(tokenizer.encode(last_output_text, add_special_tokens=False))  
+        else:  
+            print("Error: 'output_text' not found in the response string.")  
+    elif environment.parsed_options.bench_target in ["llmfixed"]:  
+        num_token_input_prompt = len(tokenizer.encode(req["query"]))  
+    elif environment.parsed_options.bench_target == "llmservefixed":  
+        content = " ".join([msg["content"] for msg in req["messages"]])  
+        num_token_input_prompt = len(tokenizer.encode(content))  
+    else:  
+        num_token_input_prompt = -1  
+ 
+    if environment.parsed_options.bench_target not in [  
+        "codetransfixed",  
+        "docsumfixed",  
+        "codegenfixed" 
+    ]:  
+        num_token_output = len(  
+            tokenizer.encode(resp["response_string"].encode("utf-8").decode("unicode_escape"), add_special_tokens=False)  
+        )  
+    
+    if environment.parsed_options.bench_target in [  
+        "codetransfixed",  
+        "codegenfixed"  
+    ]:   
+        import re  
+        raw_response = resp["response_string"]  
+        input_matches = re.findall(r'"text":"(.*?)"', raw_response)  
+        content = "".join(input_matches)  
+        num_token_output = len(  
+            tokenizer.encode((content), add_special_tokens=False)  
+        )  
 
-    num_token_output = len(
-        tokenizer.encode(resp["response_string"].encode("utf-8").decode("unicode_escape"), add_special_tokens=False)
-    )
-
-    return {
-        "tokens_input": num_token_input_prompt,
-        "tokens_output": num_token_output,
-        "first_token": resp["first_token_latency"] * 1000,
-        "next_token": (resp["total_latency"] - resp["first_token_latency"]) / (num_token_output - 1) * 1000,
-        "total_latency": resp["total_latency"] * 1000,
-        "test_start_time": resp["test_start_time"],
-    }
+    return {  
+        "tokens_input": num_token_input_prompt,  
+        "tokens_output": num_token_output,  
+        "first_token": resp["first_token_latency"] * 1000,  
+        "next_token": (resp["total_latency"] - resp["first_token_latency"]) / (num_token_output - 1) * 1000,  
+        "total_latency": resp["total_latency"] * 1000,  
+        "test_start_time": resp["test_start_time"],  
+    }  
 
 
 def staticsOutput(environment, reqlist):

--- a/evals/benchmark/stresscli/locust/tokenresponse.py
+++ b/evals/benchmark/stresscli/locust/tokenresponse.py
@@ -1,12 +1,11 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 import json
+import logging
 
 import numpy
 import transformers
-
 
 console_logger = logging.getLogger("locust.stats_logger")
 
@@ -29,21 +28,21 @@ def respStatics(environment, req, resp):
         "codegenfixed",
         "codetransfixed",
         "chatqna_qlist_pubmed",
-    ]: 
+    ]:
         num_token_input_prompt = len(tokenizer.encode(req["messages"]))
     elif environment.parsed_options.bench_target in [
         "codetransfixed",
         "codetransbench",
     ]:
-        req_str = json.dumps(req)  
+        req_str = json.dumps(req)
         num_token_input_prompt = len(tokenizer.encode(req_str))
     elif environment.parsed_options.bench_target in [
         "docsumfixed",
         "docsumbench",
     ]:
-        file_obj = req['files'][1] 
-        file_path = file_obj.name 
-        with open(file_path, 'r', encoding='utf-8') as file:
+        file_obj = req["files"][1]
+        file_path = file_obj.name
+        with open(file_path, "r", encoding="utf-8") as file:
             file_content = file.read()
         num_token_input_prompt = len(tokenizer.encode(file_content))
     elif environment.parsed_options.bench_target in ["llmfixed"]:
@@ -53,7 +52,7 @@ def respStatics(environment, req, resp):
         num_token_input_prompt = len(tokenizer.encode(content))
     else:
         num_token_input_prompt = -1
-        
+
     num_token_output = len(
         tokenizer.encode(resp["response_string"].encode("utf-8").decode("unicode_escape"), add_special_tokens=False)
     )
@@ -65,7 +64,7 @@ def respStatics(environment, req, resp):
         "next_token": (resp["total_latency"] - resp["first_token_latency"]) / (num_token_output - 1) * 1000,
         "total_latency": resp["total_latency"] * 1000,
         "test_start_time": resp["test_start_time"],
-    } 
+    }
 
 
 def staticsOutput(environment, reqlist):

--- a/evals/benchmark/stresscli/locust/tokenresponse.py
+++ b/evals/benchmark/stresscli/locust/tokenresponse.py
@@ -26,7 +26,7 @@ def respStatics(environment, req, resp):
         "faqgenfixed",
         "faqgenbench",
         "codegenfixed",
-        "codetransfixed",
+        "codegenbench",
         "chatqna_qlist_pubmed",
     ]:
         num_token_input_prompt = len(tokenizer.encode(req["messages"]))


### PR DESCRIPTION
## Issue

The previous logic implemented [[Reference](https://github.com/opea-project/GenAIEval/blob/21f618b612ce40e3f4ba174691b5aa1ed6ebfcb2/evals/benchmark/stresscli/locust/tokenresponse.py#L16C1-L50C1)] for calculating the number of input and output tokens for CodeGen, CodeTrans, and DocSum fails to provide the expected results:

- Input tokens were consistently reported as -1.
- Output tokens were overestimated due to parsing the entire response_string instead of focusing on the relevant parts

## Reason

In the currently implemented code, the token count logic assumes an output format like:

```
data: b'The'  
data: b' provided'  
data: b' text'  
data: b' is'  
data: b' a'  
data: b' collection'  
```
However, for CodeGen, CodeTrans, and DocSum, the actual output format was different. For example, in DocSum, the response_string included extraneous metadata and logs that were erroneously counted as tokens.

Example response_string (truncated for brevity):

```
{  
  "response_string": "{\"ops\":[{\"op\":\"replace\",\"path\":\"\",\"value\":{...},\"**output_text**\":\" In 2050, AI is integrated into daily life...\"}}]}"  
}
```
Only the output_text field from the response_string should be considered for output token count, but the previous logic processed other fields (e.g., ops, value), resulting in inflated counts.

## Task Accomplished

1. Fixed the input/output token count calculation logic for the bench_targets: CodeGenFixed, CodeTransFixed, and DocSumFixed.